### PR TITLE
uv-unix: Fix missing symbols on FreeBSD7 systems.

### DIFF
--- a/src/uv-unix.c
+++ b/src/uv-unix.c
@@ -62,6 +62,7 @@
 
 #if defined(__FreeBSD__)
 #include <sys/sysctl.h>
+#include <sys/wait.h>
 #endif
 
 


### PR DESCRIPTION
WEXITSTATUS and other symbols are missing when building on my FreeBSD7.3 machine. This patch fixes it simply by #include'ing sys/wait.h.
