### PR TITLE
Upstream master

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,14 @@
 /test/run-tests.dSYM
 /test/run-benchmarks
 /test/run-benchmarks.dSYM
+
+*.sln
+*.vcproj
+*.vcxproj
+*.vcxproj.filters
+*.vcxproj.user
+_UpgradeReport_Files/
+UpgradeLog*.XML
+build/Debug
+build/Release
+build/ipch

--- a/test/test-list.h
+++ b/test/test-list.h
@@ -70,6 +70,7 @@ TEST_DECLARE   (spawn_and_kill)
 #ifdef _WIN32
 TEST_DECLARE   (spawn_detect_pipe_name_collisions_on_windows)
 TEST_DECLARE   (argument_escaping)
+TEST_DECLARE   (environment_creation)
 #endif
 HELPER_DECLARE (tcp4_echo_server)
 HELPER_DECLARE (tcp6_echo_server)
@@ -155,6 +156,7 @@ TASK_LIST_START
 #ifdef _WIN32
   TEST_ENTRY  (spawn_detect_pipe_name_collisions_on_windows)
   TEST_ENTRY  (argument_escaping)
+  TEST_ENTRY  (environment_creation)
 #endif
 
 #if 0

--- a/test/test-spawn.c
+++ b/test/test-spawn.c
@@ -351,6 +351,8 @@ wchar_t* make_program_env(char** env_block);
 TEST_IMPL(environment_creation) {
   char* environment[] = {
     "FOO=BAR",
+    "SYSTEM=ROOT", /* substring of a supplied var name */
+    "SYSTEMROOTED=OMG", /* supplied var name is a substring */
     "TEMP=C:\\Temp",
     "BAZ=QUX",
     NULL

--- a/test/test-spawn.c
+++ b/test/test-spawn.c
@@ -340,6 +340,32 @@ TEST_IMPL(argument_escaping) {
   ASSERT(wcscmp(verbatim_output, L"cmd.exe /c c:\\path\\to\\node.exe --eval \"require('c:\\\\path\\\\to\\\\test.js')\"") == 0);
   ASSERT(wcscmp(non_verbatim_output, L"cmd.exe /c \"c:\\path\\to\\node.exe --eval \\\"require('c:\\\\path\\\\to\\\\test.js')\\\"\"") == 0);
 
+  free(verbatim_output);
+  free(non_verbatim_output);
+
+  return 0;
+}
+
+wchar_t* make_program_env(char** env_block);
+
+TEST_IMPL(environment_creation) {
+  char* environment[] = {
+    "FOO=BAR",
+    "TEMP=C:\\Temp",
+    "BAZ=QUX",
+    NULL
+  };
+  wchar_t* result;
+  wchar_t* str;
+  int i;
+  
+  result = make_program_env(environment);
+  ASSERT(result);
+  
+  for (str = result; *str; str += wcslen(str) + 1) {
+    wprintf(L"%s\n", str);
+  }
+  
   return 0;
 }
 #endif


### PR DESCRIPTION
Resolve the problem wherein node can't spawn itself on Windows when using a custom environment.

The root cause was that some Windows components, e.g. winsock, must have certain environment variables defined, or else they will fail to initialize properly. Even when users specify custom environments, it's unlikely that they want to break their ability to spawn typical Windows programs.

This should fix node's test-init.js.
