### PR TITLE
Fix a bug in calling memcpy with the wrong size

### DIFF
--- a/src/ares/ares_getnameinfo.c
+++ b/src/ares/ares_getnameinfo.c
@@ -187,7 +187,7 @@ void ares_getnameinfo(ares_channel channel, const struct sockaddr *sa,
         if (sa->sa_family == AF_INET)
           {
             niquery->family = AF_INET;
-            memcpy(&niquery->addr.addr4, addr, sizeof(addr));
+            memcpy(&niquery->addr.addr4, addr, sizeof(*addr));
             ares_gethostbyaddr(channel, &addr->sin_addr,
                                sizeof(struct in_addr), AF_INET,
                                nameinfo_callback, niquery);
@@ -195,7 +195,7 @@ void ares_getnameinfo(ares_channel channel, const struct sockaddr *sa,
         else
           {
             niquery->family = AF_INET6;
-            memcpy(&niquery->addr.addr6, addr6, sizeof(addr6));
+            memcpy(&niquery->addr.addr6, addr6, sizeof(*addr6));
             ares_gethostbyaddr(channel, &addr6->sin6_addr,
                                sizeof(struct ares_in6_addr), AF_INET6,
                                nameinfo_callback, niquery);


### PR DESCRIPTION
Clang warns about some other constructs, but I think this one's the only bug.
