### PR TITLE
LLVM GCC support with OS X 10.7 and Xcode 4.2

### DIFF
--- a/common.gypi
+++ b/common.gypi
@@ -143,7 +143,6 @@
           'GCC_INLINES_ARE_PRIVATE_EXTERN': 'YES',
           'GCC_SYMBOLS_PRIVATE_EXTERN': 'YES',      # -fvisibility=hidden
           'GCC_THREADSAFE_STATICS': 'NO',           # -fno-threadsafe-statics
-          'GCC_VERSION': '4.2',
           'GCC_WARN_ABOUT_MISSING_NEWLINE': 'YES',  # -Wnewline-eof
           'MACOSX_DEPLOYMENT_TARGET': '10.4',       # -mmacosx-version-min=10.4
           'PREBINDING': 'NO',                       # No -Wl,-prebind


### PR DESCRIPTION
Currently, the GYP system creates an Xcode project file with a hardcoded value for the GCC_VERSION setting. In newer versions of Xcode, plain GCC is not included. It has been replaced by LLVM-GCC, which uses GCC as a front-end for the LLVM compiler. Using a hardcoded value in the project file means that the initial build via the command line won't work:  you have to go into Xcode and switch the compiler setting to a compiler you have installed. This patch simply removes the hardcoded value, which Xcode will interpret as "use the default setting", which should work in all cases.
