### PR TITLE
Added experimental iOS support

### DIFF
--- a/src/unix/darwin.c
+++ b/src/unix/darwin.c
@@ -42,7 +42,7 @@
 /* see: http://developer.apple.com/library/mac/#qa/qa1398/_index.html */
 uint64_t uv_hrtime() {
     uint64_t time;
-    uint64_t erano;
+    uint64_t enano;
     static mach_timebase_info_data_t sTimebaseInfo;
 
     time = mach_absolute_time();
@@ -51,9 +51,9 @@ uint64_t uv_hrtime() {
         (void)mach_timebase_info(&sTimebaseInfo);
     }
 
-    erano = time * sTimebaseInfo.numer / sTimebaseInfo.denom;
+    enano = time * sTimebaseInfo.numer / sTimebaseInfo.denom;
 
-    return erano;
+    return enano;
 }
 #else
 uint64_t uv_hrtime() {


### PR DESCRIPTION
I've been using libev on iOS for long time, and hope libuv too.

Unfortunately libuv depends CoreServices.framework which is not included in iOS.
But libuv seems to depend CoreServices.framework for only AbsoluteToNanoseconds, and it's possible to replace.
This patch did this.

See also: http://developer.apple.com/library/mac/#qa/qa1398/_index.html

I also titled this experimental because I ran run-tests at my jailbroken phone but 8 tests were failed.
The output is here. https://gist.github.com/1354461
