### PR TITLE
Fix typo that broke libuv on NetBSD: psysconf() -> sysconf()

### DIFF
--- a/src/unix/netbsd.c
+++ b/src/unix/netbsd.c
@@ -91,7 +91,7 @@ uint64_t uv_get_free_memory(void) {
     return -1;
   }
 
-  return (uint64_t) info.free * psysconf(_SC_PAGESIZE);
+  return (uint64_t) info.free * sysconf(_SC_PAGESIZE);
 }
 
 uint64_t uv_get_total_memory(void) {


### PR DESCRIPTION
The psysconf() function doesn't exist and never did AFAIK. And libuv just didn't compile on NetBSD-stable because of this typo.
