### PR TITLE
Add interval and count to keep-alive

### DIFF
--- a/include/uv.h
+++ b/include/uv.h
@@ -483,9 +483,11 @@ UV_EXTERN int uv_tcp_nodelay(uv_tcp_t* handle, int enable);
 /* Enable/disable TCP keep-alive.
  *
  * `ms` is the initial delay in seconds, ignored when `enable` is zero.
+ * interval is the keep-alive probe interval after the initial delay. Doesn't work in Windows
+ * count is the number of keep-alives that fail before thinking the socket is dead. Doesn't work in Windows
  */
 UV_EXTERN int uv_tcp_keepalive(uv_tcp_t* handle, int enable,
-    unsigned int delay);
+    unsigned int delay, unsigned int interval, unsigned int count);
 
 /*
  * This setting applies to Windows only.

--- a/src/unix/internal.h
+++ b/src/unix/internal.h
@@ -132,7 +132,7 @@ int uv__connect(uv_connect_t* req, uv_stream_t* stream, struct sockaddr* addr,
 /* tcp */
 int uv_tcp_listen(uv_tcp_t* tcp, int backlog, uv_connection_cb cb);
 int uv__tcp_nodelay(uv_tcp_t* handle, int enable);
-int uv__tcp_keepalive(uv_tcp_t* handle, int enable, unsigned int delay);
+int uv__tcp_keepalive(uv_tcp_t* handle, int enable, unsigned int delay, unsigned int interval, unsigned int count);
 
 /* pipe */
 int uv_pipe_listen(uv_pipe_t* handle, int backlog, uv_connection_cb cb);

--- a/src/unix/stream.c
+++ b/src/unix/stream.c
@@ -102,7 +102,7 @@ int uv__stream_open(uv_stream_t* stream, int fd, int flags) {
 
     /* TODO Use delay the user passed in. */
     if ((stream->flags & UV_TCP_KEEPALIVE) &&
-        uv__tcp_keepalive((uv_tcp_t*)stream, 1, 60)) {
+        uv__tcp_keepalive((uv_tcp_t*)stream, 1, 60, 60, 8)) {
       return -1;
     }
   }

--- a/src/win/tcp.c
+++ b/src/win/tcp.c
@@ -59,7 +59,8 @@ static int uv__tcp_nodelay(uv_tcp_t* handle, SOCKET socket, int enable) {
 }
 
 
-static int uv__tcp_keepalive(uv_tcp_t* handle, SOCKET socket, int enable, unsigned int delay) {
+static int uv__tcp_keepalive(uv_tcp_t* handle, SOCKET socket, int enable, unsigned int delay,
+    unsigned int interval, unsigned int count) {
   if (setsockopt(socket,
                  SOL_SOCKET,
                  SO_KEEPALIVE,
@@ -77,6 +78,11 @@ static int uv__tcp_keepalive(uv_tcp_t* handle, SOCKET socket, int enable, unsign
     uv__set_sys_error(handle->loop, errno);
     return -1;
   }
+
+  /*
+   * interval and count cannot be applied without registry
+   * changes and system reboot
+   */
 
   return 0;
 }
@@ -132,7 +138,7 @@ static int uv_tcp_set_socket(uv_loop_t* loop, uv_tcp_t* handle,
 
   /* TODO: Use stored delay. */
   if ((handle->flags & UV_HANDLE_TCP_KEEPALIVE) &&
-      uv__tcp_keepalive(handle, socket, 1, 60)) {
+      uv__tcp_keepalive(handle, socket, 1, 60, 60, 8)) {
     return -1;
   }
 
@@ -1058,9 +1064,9 @@ int uv_tcp_nodelay(uv_tcp_t* handle, int enable) {
 }
 
 
-int uv_tcp_keepalive(uv_tcp_t* handle, int enable, unsigned int delay) {
+int uv_tcp_keepalive(uv_tcp_t* handle, int enable, unsigned int delay, unsigned int interval, unsigned int count) {
   if (handle->socket != INVALID_SOCKET &&
-      uv__tcp_keepalive(handle, handle->socket, enable, delay)) {
+      uv__tcp_keepalive(handle, handle->socket, enable, delay, interval, count)) {
     return -1;
   }
 

--- a/test/test-tcp-flags.c
+++ b/test/test-tcp-flags.c
@@ -39,7 +39,7 @@ TEST_IMPL(tcp_flags) {
   r = uv_tcp_nodelay(&handle, 1);
   ASSERT(r == 0);
 
-  r = uv_tcp_keepalive(&handle, 1, 60);
+  r = uv_tcp_keepalive(&handle, 1, 60, 60, 8);
   ASSERT(r == 0);
 
   uv_close((uv_handle_t*)&handle, NULL);


### PR DESCRIPTION
We should be able to specify the probe interval and the failure count for keep-alive's on sockets.

Corresponding node pull request: https://github.com/joyent/node/pull/2239
