### PR TITLE
test: make test runner return non-zero in case of failure

### DIFF
--- a/test/runner.c
+++ b/test/runner.c
@@ -71,7 +71,7 @@ int run_tests(int timeout, int benchmark_output) {
     log_progress(total, passed, failed, "Done.\n");
   }
 
-  return 0;
+  return failed;
 }
 
 


### PR DESCRIPTION
Test runner always exited with 0.
