### PR TITLE
Map `ENAMETOOLONG`

### DIFF
--- a/include/uv.h
+++ b/include/uv.h
@@ -115,7 +115,8 @@ typedef intptr_t ssize_t;
   XX( 45, EAISOCKTYPE, "") \
   XX( 46, ESHUTDOWN, "") \
   XX( 47, EEXIST, "file already exists") \
-  XX( 48, ESRCH, "no such process")
+  XX( 48, ESRCH, "no such process") \
+  XX( 49, ENAMETOOLONG, "name too long")
 
 
 #define UV_ERRNO_GEN(val, name, s) UV_##name = val,

--- a/src/unix/error.c
+++ b/src/unix/error.c
@@ -71,6 +71,7 @@ uv_err_code uv_translate_sys_error(int sys_errno) {
     case EFAULT: return UV_EFAULT;
     case EMFILE: return UV_EMFILE;
     case EMSGSIZE: return UV_EMSGSIZE;
+    case ENAMETOOLONG: return UV_ENAMETOOLONG;
     case EINVAL: return UV_EINVAL;
     case ECONNREFUSED: return UV_ECONNREFUSED;
     case EADDRINUSE: return UV_EADDRINUSE;

--- a/test/test-list.h
+++ b/test/test-list.h
@@ -103,6 +103,7 @@ TEST_DECLARE   (spawn_and_kill)
 TEST_DECLARE   (spawn_and_ping)
 TEST_DECLARE   (kill)
 TEST_DECLARE   (fs_file_noent)
+TEST_DECLARE   (fs_file_nametoolong)
 TEST_DECLARE   (fs_file_async)
 TEST_DECLARE   (fs_file_sync)
 TEST_DECLARE   (fs_async_dir)
@@ -269,6 +270,7 @@ TASK_LIST_START
 #endif
 
   TEST_ENTRY  (fs_file_noent)
+  TEST_ENTRY  (fs_file_nametoolong)
   TEST_ENTRY  (fs_file_async)
   TEST_ENTRY  (fs_file_sync)
   TEST_ENTRY  (fs_async_dir)


### PR DESCRIPTION
I haven't done the Windows part - Windows seems to call `ENAMETOOLONG` `ERROR_BUFFER_OVERFLOW`, which is way too vague to me (and I have no machine to test it on).

Test included.

Fixes #247.
