### PR TITLE
uv.h: add EPERM to errno map to fix regression

### DIFF
--- a/include/uv.h
+++ b/include/uv.h
@@ -115,7 +115,8 @@ typedef intptr_t ssize_t;
   XX( 45, EAISOCKTYPE, "") \
   XX( 46, ESHUTDOWN, "") \
   XX( 47, EEXIST, "file already exists") \
-  XX( 48, ESRCH, "no such process")
+  XX( 48, ESRCH, "no such process") \
+  XX( 49, EPERM, "operation not permitted")
 
 
 #define UV_ERRNO_GEN(val, name, s) UV_##name = val,

--- a/src/unix/error.c
+++ b/src/unix/error.c
@@ -59,6 +59,7 @@ void uv_fatal_error(const int errorno, const char* syscall) {
 uv_err_code uv_translate_sys_error(int sys_errno) {
   switch (sys_errno) {
     case 0: return UV_OK;
+    case EPERM: return UV_EPERM;
     case ENOSYS: return UV_ENOSYS;
     case ENOTSOCK: return UV_ENOTSOCK;
     case ENOENT: return UV_ENOENT;

--- a/test/test-fs.c
+++ b/test/test-fs.c
@@ -183,6 +183,13 @@ static void chown_cb(uv_fs_t* req) {
   uv_fs_req_cleanup(req);
 }
 
+static void chown_root_cb(uv_fs_t* req) {
+  ASSERT(req->fs_type == UV_FS_CHOWN);
+  ASSERT(req->result == -1);
+  ASSERT(req->errorno == UV_EPERM);
+  chown_cb_count++;
+  uv_fs_req_cleanup(req);
+}
 
 static void unlink_cb(uv_fs_t* req) {
   ASSERT(req == &unlink_req);
@@ -981,6 +988,12 @@ TEST_IMPL(fs_chown) {
   /* async chown */
   r = uv_fs_chown(loop, &req, "test_file", -1, -1, chown_cb);
   ASSERT(r == 0);
+  uv_run(loop);
+  ASSERT(chown_cb_count == 1);
+
+  /* chown to root (fail) */
+  chown_cb_count = 0;
+  r = uv_fs_chown(loop, &req, "test_file", 0, 0, chown_root_cb);
   uv_run(loop);
   ASSERT(chown_cb_count == 1);
 


### PR DESCRIPTION
EPERM isn't mapped in so chown returns an unknown error. This is a
regression from 0.4.12.

philips:node/ (master*) $ cat chown.js
var fs = require('fs')
fs.chown("/tmp/foobar", 100, 100, function(er){ console.log(er);})

philips:node/ (master*) $ ls -la /tmp/foobar
total 0
drwxr-xr-x   2 root  wheel   68 Jan 24 17:21 .
## 0.4

philips:node/ (master*) $ /usr/local/Cellar/node/0.4.12/bin/node chown.js
{ stack: [Getter/Setter],
  arguments: undefined,
  type: undefined,
  message: 'EPERM, Operation not permitted \'/tmp/foobar\'',
  errno: 1,
  code: 'EPERM',
  path: '/tmp/foobar' }
## master

philips:node/ (master*) $ ./node chown.js
{ [Error: UNKNOWN, unknown error '/tmp/foobar'] errno: -1, code: 'UNKNOWN', path: '/tmp/foobar' }
## AFTER

philips:node/ (master*) $ ./node chown.js
{ [Error: EPERM, operation not permitted '/tmp/foobar'] errno: 49, code: 'EPERM', path: '/tmp/foobar' }

This is also needed to fix isaacs/npm#2080 under 0.6 and make npm work on nfs squashed filesystems.
