### PR TITLE
Add EXDEV to the errno map.

### DIFF
--- a/include/uv.h
+++ b/include/uv.h
@@ -117,7 +117,8 @@ typedef intptr_t ssize_t;
   XX( 47, EEXIST, "file already exists") \
   XX( 48, ESRCH, "no such process") \
   XX( 49, ENAMETOOLONG, "name too long") \
-  XX( 50, EPERM, "operation not permitted")
+  XX( 50, EPERM, "operation not permitted") \
+  XX( 51, EXDEV, "cross-device link not permitted")
 
 
 #define UV_ERRNO_GEN(val, name, s) UV_##name = val,

--- a/src/unix/error.c
+++ b/src/unix/error.c
@@ -85,6 +85,7 @@ uv_err_code uv_translate_sys_error(int sys_errno) {
     case EAI_NONAME: return UV_ENOENT;
     case ESRCH: return UV_ESRCH;
     case ETIMEDOUT: return UV_ETIMEDOUT;
+    case EXDEV: return UV_EXDEV;
     default: return UV_UNKNOWN;
   }
   UNREACHABLE();


### PR DESCRIPTION
Fixes the "UNKNOWN" errno first reported in joyent/node#2703.

I tried adding a test case, but I couldn't figure out how to detect a remote network path, so I wasn't sure if it was possible.

Also, there might be an additional change needed for Windows, I wasn't quite sure.
