### PR TITLE
Fixes for *BSD systems.

### DIFF
--- a/src/unix/netbsd.c
+++ b/src/unix/netbsd.c
@@ -54,10 +54,6 @@ void uv_loadavg(double avg[3]) {
 }
 
 int uv_exepath(char* buffer, size_t* size) {
-  uint32_t usize;
-  int result;
-  char* path;
-  char* fullpath;
   int mib[4];
   size_t cb;
   pid_t mypid;


### PR DESCRIPTION
This pull request fixes a bunch of things on BSD systems:
- Remove unused variables on NetBSD
- libuv didn't compile any more on OpenBSD and was using a kvm interface that doesn't exist any more
- uv_resident_set_memory() and uv_cpu_info() didn't work on Dragonfly BSD
