### PR TITLE
win: fs: handle EOF in read

### DIFF
--- a/src/win/fs.c
+++ b/src/win/fs.c
@@ -294,6 +294,7 @@ void fs__read(uv_fs_t* req, uv_file file, void *buf, size_t length,
   OVERLAPPED overlapped, *overlapped_ptr;
   LARGE_INTEGER offset_;
   DWORD bytes;
+  DWORD error;
 
   VERIFY_UV_FILE(file, req);
 
@@ -323,7 +324,12 @@ void fs__read(uv_fs_t* req, uv_file file, void *buf, size_t length,
   if (ReadFile(handle, buf, length, &bytes, overlapped_ptr)) {
     SET_REQ_RESULT(req, bytes);
   } else {
-    SET_REQ_WIN32_ERROR(req, GetLastError());
+    error = GetLastError();
+    if (error == ERROR_HANDLE_EOF) {
+      SET_REQ_RESULT(req, bytes);
+    } else {
+      SET_REQ_WIN32_ERROR(req, error);
+    }
   }
 }
 


### PR DESCRIPTION
in luvit after we upgraded libuv from 243cfc to d3efef readSync started
failing.  It seems that the code cleanup stopped handling EOF

Trivially reproduced with this

```
local fs = require('fs')
print(fs.readFileSync('foo.luvit'))
```
