### PR TITLE
Fix memory leak in uv_exepath() on OSX.

### DIFF
--- a/src/unix/darwin.c
+++ b/src/unix/darwin.c
@@ -73,7 +73,6 @@ uint64_t uv_hrtime() {
 int uv_exepath(char* buffer, size_t* size) {
   uint32_t usize;
   int result;
-  char* path;
   char* fullpath;
 
   if (!buffer || !size) {
@@ -84,11 +83,9 @@ int uv_exepath(char* buffer, size_t* size) {
   result = _NSGetExecutablePath(buffer, &usize);
   if (result) return result;
 
-  path = (char*)malloc(2 * PATH_MAX);
-  fullpath = realpath(buffer, path);
+  fullpath = realpath(buffer, NULL);
 
   if (fullpath == NULL) {
-    free(path);
     return -1;
   }
 


### PR DESCRIPTION
The uv_exepath() function leaks memory on OSX. We don't need to pre-malloc() a buffer for the result of realpath(). Just pass NULL for the resolved path.
