### PR TITLE
Windows: we need to zero the loop structure when we initialize it

### DIFF
--- a/src/win/core.c
+++ b/src/win/core.c
@@ -59,6 +59,7 @@ static void uv_init(void) {
 
 
 static void uv_loop_init(uv_loop_t* loop) {
+  loop->uv_ares_handles_ = NULL;
   /* Create an I/O completion port */
   loop->iocp = CreateIoCompletionPort(INVALID_HANDLE_VALUE, NULL, 0, 1);
   if (loop->iocp == NULL) {


### PR DESCRIPTION
or else the list of ares handles is uninitialized and bad things can happen when we try to perform async lookups.
