### PR TITLE
map ENETUNREACH to UV_ENETUNREACH

### DIFF
--- a/src/unix/error.c
+++ b/src/unix/error.c
@@ -74,6 +74,7 @@ uv_err_code uv_translate_sys_error(int sys_errno) {
     case EMSGSIZE: return UV_EMSGSIZE;
     case ENAMETOOLONG: return UV_ENAMETOOLONG;
     case EINVAL: return UV_EINVAL;
+    case ENETUNREACH: return UV_ENETUNREACH;
     case ECONNABORTED: return UV_ECONNABORTED;
     case ELOOP: return UV_ELOOP;
     case ECONNREFUSED: return UV_ECONNREFUSED;


### PR DESCRIPTION
UV_ENETUNREACH already exists, but was not mapped properly on unix.  This is the case on both `master` and in `v0.6`.
