### PR TITLE
Don't link with Carbon framework when using gyp (on Darwin)

### DIFF
--- a/uv.gyp
+++ b/uv.gyp
@@ -211,7 +211,6 @@
           'sources': [ 'src/unix/darwin.c' ],
           'direct_dependent_settings': {
             'libraries': [
-              '$(SDKROOT)/System/Library/Frameworks/Carbon.framework',
               '$(SDKROOT)/System/Library/Frameworks/CoreServices.framework',
             ],
           },


### PR DESCRIPTION
AFAIK it's not needed, the plain makefiles don't do it and test suite runs just fine without linking with it.
