### PR TITLE
Added missing function declaration

### DIFF
--- a/src/unix/internal.h
+++ b/src/unix/internal.h
@@ -151,6 +151,7 @@ void uv__process_close(uv_process_t* handle);
 void uv__stream_close(uv_stream_t* handle);
 void uv__timer_close(uv_timer_t* handle);
 void uv__udp_close(uv_udp_t* handle);
+void uv__udp_finish_close(uv_udp_t* handle);
 
 #define UV__F_IPC        (1 << 0)
 #define UV__F_NONBLOCK   (1 << 1)


### PR DESCRIPTION
Fixes compilation warning about uv__udp_finish_close being implicitly declared.
