### PR TITLE
Update c-ares

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,6 +53,7 @@ CARES_OBJS += src/ares/ares_options.o
 CARES_OBJS += src/ares/ares_parse_a_reply.o
 CARES_OBJS += src/ares/ares_parse_aaaa_reply.o
 CARES_OBJS += src/ares/ares_parse_mx_reply.o
+CARES_OBJS += src/ares/ares_parse_naptr_reply.o
 CARES_OBJS += src/ares/ares_parse_ns_reply.o
 CARES_OBJS += src/ares/ares_parse_ptr_reply.o
 CARES_OBJS += src/ares/ares_parse_srv_reply.o

--- a/include/ares.h
+++ b/include/ares.h
@@ -513,6 +513,16 @@ struct ares_txt_reply {
   size_t                  length;  /* length excludes null termination */
 };
 
+struct ares_naptr_reply {
+  struct ares_naptr_reply *next;
+  unsigned char           *flags;
+  unsigned char           *service;
+  unsigned char           *regexp;
+  char                    *replacement;
+  unsigned short           order;
+  unsigned short           preference;
+};
+
 /*
 ** Parse the buffer, starting at *abuf and of length alen bytes, previously
 ** obtained from an ares_search call.  Put the results in *host, if nonnull.
@@ -555,6 +565,10 @@ CARES_EXTERN int ares_parse_mx_reply(const unsigned char* abuf,
 CARES_EXTERN int ares_parse_txt_reply(const unsigned char* abuf,
                                       int alen,
                                       struct ares_txt_reply** txt_out);
+
+CARES_EXTERN int ares_parse_naptr_reply(const unsigned char* abuf,
+                                        int alen,
+                                        struct ares_naptr_reply** naptr_out);
 
 CARES_EXTERN void ares_free_string(void *str);
 

--- a/include/ares_version.h
+++ b/include/ares_version.h
@@ -3,15 +3,15 @@
 #define ARES__VERSION_H
 
 /* This is the global package copyright */
-#define ARES_COPYRIGHT "2004 - 2010 Daniel Stenberg, <daniel@haxx.se>."
+#define ARES_COPYRIGHT "2004 - 2011 Daniel Stenberg, <daniel@haxx.se>."
 
 #define ARES_VERSION_MAJOR 1
 #define ARES_VERSION_MINOR 7
-#define ARES_VERSION_PATCH 5
+#define ARES_VERSION_PATCH 6
 #define ARES_VERSION ((ARES_VERSION_MAJOR<<16)|\
                        (ARES_VERSION_MINOR<<8)|\
                        (ARES_VERSION_PATCH))
-#define ARES_VERSION_STR "1.7.5-DEV"
+#define ARES_VERSION_STR "1.7.6-DEV"
 
 #if (ARES_VERSION >= 0x010700)
 #  define CARES_HAVE_ARES_LIBRARY_INIT 1

--- a/src/ares/README.node
+++ b/src/ares/README.node
@@ -1,6 +1,6 @@
 Library: c-ares, DNS resolver
 
-Version: 1.7.3 (11 June, 2010)
+Version: 1.7.6-dev (April, 2012)
 
 Authors: Greg Hudson, Daniel Stenberg
 
@@ -13,8 +13,6 @@ the documentation and other files distributed with it. To upgrade, run
 ./configure on linux, macintosh, solaris (and other supported platforms) and
 copy
 - ares_config.h
-- ares_setup.h
-- ares_build.h
 into the appropriate directory.
 
 

--- a/src/ares/ares__get_hostent.c
+++ b/src/ares/ares__get_hostent.c
@@ -1,5 +1,5 @@
 
-/* Copyright 1998, 2010 by the Massachusetts Institute of Technology.
+/* Copyright 1998, 2011 by the Massachusetts Institute of Technology.
  *
  * Permission to use, copy, modify, and distribute this
  * software and its documentation for any purpose and without
@@ -31,6 +31,7 @@
 
 #include "ares.h"
 #include "inet_net_pton.h"
+#include "ares_nowarn.h"
 #include "ares_private.h"
 
 int ares__get_hostent(FILE *fp, int family, struct hostent **host)
@@ -219,8 +220,8 @@ int ares__get_hostent(FILE *fp, int family, struct hostent **host)
         break;
 
       /* Copy actual network address family and length. */
-      hostent->h_addrtype = addr.family;
-      hostent->h_length = (int)addrlen;
+      hostent->h_addrtype = aresx_sitoss(addr.family);
+      hostent->h_length = aresx_uztoss(addrlen);
 
       /* Free line buffer. */
       free(line);

--- a/src/ares/ares_data.c
+++ b/src/ares/ares_data.c
@@ -1,5 +1,5 @@
 
-/* Copyright (C) 2009-2010 by Daniel Stenberg
+/* Copyright (C) 2009-2012 by Daniel Stenberg
  *
  * Permission to use, copy, modify, and distribute this
  * software and its documentation for any purpose and without
@@ -92,6 +92,20 @@ void ares_free_data(void *dataptr)
           ares_free_data(ptr->data.addr_node.next);
         break;
 
+      case ARES_DATATYPE_NAPTR_REPLY:
+
+        if (ptr->data.naptr_reply.next)
+          ares_free_data(ptr->data.naptr_reply.next);
+        if (ptr->data.naptr_reply.flags)
+          free(ptr->data.naptr_reply.flags);
+        if (ptr->data.naptr_reply.service)
+          free(ptr->data.naptr_reply.service);
+        if (ptr->data.naptr_reply.regexp)
+          free(ptr->data.naptr_reply.regexp);
+        if (ptr->data.naptr_reply.replacement)
+          free(ptr->data.naptr_reply.replacement);
+        break;
+
       default:
         return;
     }
@@ -138,7 +152,7 @@ void *ares_malloc_data(ares_datatype type)
       case ARES_DATATYPE_TXT_REPLY:
         ptr->data.txt_reply.next = NULL;
         ptr->data.txt_reply.txt = NULL;
-        ptr->data.txt_reply.length  = 0;
+        ptr->data.txt_reply.length = 0;
         break;
 
       case ARES_DATATYPE_ADDR_NODE:
@@ -146,6 +160,16 @@ void *ares_malloc_data(ares_datatype type)
         ptr->data.addr_node.family = 0;
         memset(&ptr->data.addr_node.addrV6, 0,
                sizeof(ptr->data.addr_node.addrV6));
+        break;
+
+      case ARES_DATATYPE_NAPTR_REPLY:
+        ptr->data.naptr_reply.next = NULL;
+        ptr->data.naptr_reply.flags = NULL;
+        ptr->data.naptr_reply.service = NULL;
+        ptr->data.naptr_reply.regexp = NULL;
+        ptr->data.naptr_reply.replacement = NULL;
+        ptr->data.naptr_reply.order = 0;
+        ptr->data.naptr_reply.preference = 0;
         break;
 
       default:

--- a/src/ares/ares_data.h
+++ b/src/ares/ares_data.h
@@ -20,6 +20,7 @@ typedef enum {
   ARES_DATATYPE_TXT_REPLY,    /* struct ares_txt_reply - introduced in 1.7.0 */
   ARES_DATATYPE_ADDR_NODE,    /* struct ares_addr_node - introduced in 1.7.1 */
   ARES_DATATYPE_MX_REPLY,    /* struct ares_mx_reply   - introduced in 1.7.2 */
+  ARES_DATATYPE_NAPTR_REPLY,/* struct ares_naptr_reply - introduced in 1.7.6 */
 #if 0
   ARES_DATATYPE_ADDR6TTL,     /* struct ares_addrttl   */
   ARES_DATATYPE_ADDRTTL,      /* struct ares_addr6ttl  */
@@ -53,10 +54,11 @@ struct ares_data {
   ares_datatype type;  /* Actual data type identifier. */
   unsigned int  mark;  /* Private ares_data signature. */
   union {
-    struct ares_txt_reply txt_reply;
-    struct ares_srv_reply srv_reply;
-    struct ares_addr_node addr_node;
-    struct ares_mx_reply mx_reply;
+    struct ares_txt_reply   txt_reply;
+    struct ares_srv_reply   srv_reply;
+    struct ares_addr_node   addr_node;
+    struct ares_mx_reply    mx_reply;
+    struct ares_naptr_reply naptr_reply;
   } data;
 };
 

--- a/src/ares/ares_destroy.c
+++ b/src/ares/ares_destroy.c
@@ -1,6 +1,6 @@
 
 /* Copyright 1998 by the Massachusetts Institute of Technology.
- * Copyright (C) 2004-2010 by Daniel Stenberg
+ * Copyright (C) 2004-2011 by Daniel Stenberg
  *
  * Permission to use, copy, modify, and distribute this
  * software and its documentation for any purpose and without
@@ -29,10 +29,12 @@ void ares_destroy_options(struct ares_options *options)
     free(options->servers);
   for (i = 0; i < options->ndomains; i++)
     free(options->domains[i]);
-  free(options->domains);
+  if(options->domains)
+    free(options->domains);
   if(options->sortlist)
     free(options->sortlist);
-  free(options->lookups);
+  if(options->lookups)
+    free(options->lookups);
 }
 
 void ares_destroy(ares_channel channel)

--- a/src/ares/ares_dns.h
+++ b/src/ares/ares_dns.h
@@ -1,5 +1,7 @@
+#ifndef HEADER_CARES_DNS_H
+#define HEADER_CARES_DNS_H
 
-/* Copyright 1998 by the Massachusetts Institute of Technology.
+/* Copyright 1998, 2011 by the Massachusetts Institute of Technology.
  *
  * Permission to use, copy, modify, and distribute this
  * software and its documentation for any purpose and without
@@ -14,12 +16,23 @@
  * without express or implied warranty.
  */
 
-#ifndef ARES__DNS_H
-#define ARES__DNS_H
+/*
+ * Macro DNS__16BIT reads a network short (16 bit) given in network
+ * byte order, and returns its value as an unsigned short.
+ */
+#define DNS__16BIT(p)  ((unsigned short)((unsigned int) 0xffff & \
+                         (((unsigned int)((unsigned char)(p)[0]) << 8U) | \
+                          ((unsigned int)((unsigned char)(p)[1])))))
 
-#define DNS__16BIT(p)                   (((p)[0] << 8) | (p)[1])
-#define DNS__32BIT(p)                   (((p)[0] << 24) | ((p)[1] << 16) | \
-                                         ((p)[2] << 8) | (p)[3])
+/*
+ * Macro DNS__32BIT reads a network long (32 bit) given in network
+ * byte order, and returns its value as an unsigned int.
+ */
+#define DNS__32BIT(p)  ((unsigned int) \
+                         (((unsigned int)((unsigned char)(p)[0]) << 24U) | \
+                          ((unsigned int)((unsigned char)(p)[1]) << 16U) | \
+                          ((unsigned int)((unsigned char)(p)[2]) <<  8U) | \
+                          ((unsigned int)((unsigned char)(p)[3]))))
 
 #define DNS__SET16BIT(p, v)  (((p)[0] = (unsigned char)(((v) >> 8) & 0xff)), \
                               ((p)[1] = (unsigned char)((v) & 0xff)))
@@ -87,4 +100,4 @@
 #define DNS_RR_SET_TTL(r)               DNS__SET32BIT((r) + 4, v)
 #define DNS_RR_SET_LEN(r)               DNS__SET16BIT((r) + 8, v)
 
-#endif /* ARES__DNS_H */
+#endif /* HEADER_CARES_DNS_H */

--- a/src/ares/ares_expand_name.c
+++ b/src/ares/ares_expand_name.c
@@ -1,5 +1,5 @@
 
-/* Copyright 1998 by the Massachusetts Institute of Technology.
+/* Copyright 1998, 2011 by the Massachusetts Institute of Technology.
  *
  * Permission to use, copy, modify, and distribute this
  * software and its documentation for any purpose and without
@@ -33,6 +33,7 @@
 
 #include <stdlib.h>
 #include "ares.h"
+#include "ares_nowarn.h"
 #include "ares_private.h" /* for the memdebug */
 
 static int name_length(const unsigned char *encoded, const unsigned char *abuf,
@@ -91,9 +92,9 @@ int ares_expand_name(const unsigned char *encoded, const unsigned char *abuf,
     /* indirect root label (like 0xc0 0x0c) is 2 bytes long (stupid, but
        valid) */
     if ((*encoded & INDIR_MASK) == INDIR_MASK)
-      *enclen = 2;
+      *enclen = 2L;
     else
-      *enclen = 1;  /* the caller should move one byte to get past this */
+      *enclen = 1L;  /* the caller should move one byte to get past this */
 
     return ARES_SUCCESS;
   }
@@ -106,7 +107,7 @@ int ares_expand_name(const unsigned char *encoded, const unsigned char *abuf,
         {
           if (!indir)
             {
-              *enclen = p + 2 - encoded;
+              *enclen = aresx_uztosl(p + 2U - encoded);
               indir = 1;
             }
           p = abuf + ((*p & ~INDIR_MASK) << 8 | *(p + 1));
@@ -126,7 +127,7 @@ int ares_expand_name(const unsigned char *encoded, const unsigned char *abuf,
         }
     }
   if (!indir)
-    *enclen = p + 1 - encoded;
+    *enclen = aresx_uztosl(p + 1U - encoded);
 
   /* Nuke the trailing period if we wrote one. */
   if (q > *s)

--- a/src/ares/ares_gethostbyname.c
+++ b/src/ares/ares_gethostbyname.c
@@ -1,5 +1,5 @@
 
-/* Copyright 1998 by the Massachusetts Institute of Technology.
+/* Copyright 1998, 2011 by the Massachusetts Institute of Technology.
  *
  * Permission to use, copy, modify, and distribute this
  * software and its documentation for any purpose and without
@@ -49,6 +49,7 @@
 #include "inet_net_pton.h"
 #include "bitncmp.h"
 #include "ares_platform.h"
+#include "ares_nowarn.h"
 #include "ares_private.h"
 
 #ifdef WATT32
@@ -300,7 +301,7 @@ static int fake_hostent(const char *name, int family,
   /* Fill in the rest of the host structure and terminate the query. */
   addrs[1] = NULL;
   hostent.h_aliases = aliases;
-  hostent.h_addrtype = family;
+  hostent.h_addrtype = aresx_sitoss(family);
   hostent.h_addr_list = addrs;
   callback(arg, ARES_SUCCESS, 0, &hostent);
 

--- a/src/ares/ares_getnameinfo.c
+++ b/src/ares/ares_getnameinfo.c
@@ -188,7 +188,7 @@ void ares_getnameinfo(ares_channel channel, const struct sockaddr *sa,
         if (sa->sa_family == AF_INET)
           {
             niquery->family = AF_INET;
-            memcpy(&niquery->addr.addr4, addr, sizeof(struct in_addr));
+            memcpy(&niquery->addr.addr4, addr, sizeof(niquery->addr.addr4));
             ares_gethostbyaddr(channel, &addr->sin_addr,
                                sizeof(struct in_addr), AF_INET,
                                nameinfo_callback, niquery);
@@ -196,7 +196,7 @@ void ares_getnameinfo(ares_channel channel, const struct sockaddr *sa,
         else
           {
             niquery->family = AF_INET6;
-            memcpy(&niquery->addr.addr6, addr6, sizeof(struct ares_in6_addr));
+            memcpy(&niquery->addr.addr6, addr6, sizeof(niquery->addr.addr6));
             ares_gethostbyaddr(channel, &addr6->sin6_addr,
                                sizeof(struct ares_in6_addr), AF_INET6,
                                nameinfo_callback, niquery);

--- a/src/ares/ares_library_init.h
+++ b/src/ares/ares_library_init.h
@@ -23,7 +23,7 @@
 #ifdef USE_WINSOCK
 
 #include <iphlpapi.h>
-#include <ares_iphlpapi.h>
+#include "ares_iphlpapi.h"
 
 typedef DWORD (WINAPI *fpGetNetworkParams_t) (FIXED_INFO*, DWORD*);
 typedef BOOLEAN (APIENTRY *fpSystemFunction036_t) (void*, ULONG);

--- a/src/ares/ares_library_init.h
+++ b/src/ares/ares_library_init.h
@@ -23,7 +23,7 @@
 #ifdef USE_WINSOCK
 
 #include <iphlpapi.h>
-#include "ares_iphlpapi.h"
+#include <ares_iphlpapi.h>
 
 typedef DWORD (WINAPI *fpGetNetworkParams_t) (FIXED_INFO*, DWORD*);
 typedef BOOLEAN (APIENTRY *fpSystemFunction036_t) (void*, ULONG);

--- a/src/ares/ares_nowarn.c
+++ b/src/ares/ares_nowarn.c
@@ -39,6 +39,19 @@
 
 #include "ares_nowarn.h"
 
+#if (SIZEOF_SHORT == 2)
+#  define CARES_MASK_SSHORT  0x7FFF
+#  define CARES_MASK_USHORT  0xFFFF
+#elif (SIZEOF_SHORT == 4)
+#  define CARES_MASK_SSHORT  0x7FFFFFFF
+#  define CARES_MASK_USHORT  0xFFFFFFFF
+#elif (SIZEOF_SHORT == 8)
+#  define CARES_MASK_SSHORT  0x7FFFFFFFFFFFFFFF
+#  define CARES_MASK_USHORT  0xFFFFFFFFFFFFFFFF
+#else
+#  error "SIZEOF_SHORT not defined"
+#endif
+
 #if (SIZEOF_INT == 2)
 #  define CARES_MASK_SINT  0x7FFF
 #  define CARES_MASK_UINT  0xFFFF
@@ -51,7 +64,43 @@
 #elif (SIZEOF_INT == 16)
 #  define CARES_MASK_SINT  0x7FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF
 #  define CARES_MASK_UINT  0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF
+#else
+#  error "SIZEOF_INT not defined"
 #endif
+
+#if (CARES_SIZEOF_LONG == 2)
+#  define CARES_MASK_SLONG  0x7FFFL
+#  define CARES_MASK_ULONG  0xFFFFUL
+#elif (CARES_SIZEOF_LONG == 4)
+#  define CARES_MASK_SLONG  0x7FFFFFFFL
+#  define CARES_MASK_ULONG  0xFFFFFFFFUL
+#elif (CARES_SIZEOF_LONG == 8)
+#  define CARES_MASK_SLONG  0x7FFFFFFFFFFFFFFFL
+#  define CARES_MASK_ULONG  0xFFFFFFFFFFFFFFFFUL
+#elif (CARES_SIZEOF_LONG == 16)
+#  define CARES_MASK_SLONG  0x7FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFL
+#  define CARES_MASK_ULONG  0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFUL
+#else
+#  error "CARES_SIZEOF_LONG not defined"
+#endif
+
+/*
+** unsigned size_t to signed long
+*/
+
+long aresx_uztosl(size_t uznum)
+{
+#ifdef __INTEL_COMPILER
+#  pragma warning(push)
+#  pragma warning(disable:810) /* conversion may lose significant bits */
+#endif
+
+  return (long)(uznum & (size_t) CARES_MASK_SLONG);
+
+#ifdef __INTEL_COMPILER
+#  pragma warning(pop)
+#endif
+}
 
 /*
 ** unsigned size_t to signed int
@@ -65,6 +114,43 @@ int aresx_uztosi(size_t uznum)
 #endif
 
   return (int)(uznum & (size_t) CARES_MASK_SINT);
+
+#ifdef __INTEL_COMPILER
+#  pragma warning(pop)
+#endif
+}
+
+/*
+** unsigned size_t to signed short
+*/
+
+short aresx_uztoss(size_t uznum)
+{
+#ifdef __INTEL_COMPILER
+#  pragma warning(push)
+#  pragma warning(disable:810) /* conversion may lose significant bits */
+#endif
+
+  return (short)(uznum & (size_t) CARES_MASK_SSHORT);
+
+#ifdef __INTEL_COMPILER
+#  pragma warning(pop)
+#endif
+}
+
+/*
+** signed int to signed short
+*/
+
+short aresx_sitoss(int sinum)
+{
+#ifdef __INTEL_COMPILER
+#  pragma warning(push)
+#  pragma warning(disable:810) /* conversion may lose significant bits */
+#endif
+
+  DEBUGASSERT(sinum >= 0);
+  return (short)(sinum & (int) CARES_MASK_SSHORT);
 
 #ifdef __INTEL_COMPILER
 #  pragma warning(pop)

--- a/src/ares/ares_nowarn.h
+++ b/src/ares/ares_nowarn.h
@@ -17,7 +17,11 @@
  * without express or implied warranty.
  */
 
-int aresx_uztosi(size_t uznum);
+long  aresx_uztosl(size_t uznum);
+int   aresx_uztosi(size_t uznum);
+short aresx_uztoss(size_t uznum);
+
+short aresx_sitoss(int sinum);
 
 int aresx_sltosi(long slnum);
 

--- a/src/ares/ares_parse_naptr_reply.c
+++ b/src/ares/ares_parse_naptr_reply.c
@@ -1,0 +1,188 @@
+
+/* Copyright 1998 by the Massachusetts Institute of Technology.
+ * Copyright (C) 2009 by Jakub Hrozek <jhrozek@redhat.com>
+ *
+ * Permission to use, copy, modify, and distribute this
+ * software and its documentation for any purpose and without
+ * fee is hereby granted, provided that the above copyright
+ * notice appear in all copies and that both that copyright
+ * notice and this permission notice appear in supporting
+ * documentation, and that the name of M.I.T. not be used in
+ * advertising or publicity pertaining to distribution of the
+ * software without specific, written prior permission.
+ * M.I.T. makes no representations about the suitability of
+ * this software for any purpose.  It is provided "as is"
+ * without express or implied warranty.
+ */
+
+#include "ares_setup.h"
+
+#ifdef HAVE_SYS_SOCKET_H
+#  include <sys/socket.h>
+#endif
+#ifdef HAVE_NETINET_IN_H
+#  include <netinet/in.h>
+#endif
+#ifdef HAVE_NETDB_H
+#  include <netdb.h>
+#endif
+#ifdef HAVE_ARPA_INET_H
+#  include <arpa/inet.h>
+#endif
+#ifdef HAVE_ARPA_NAMESER_H
+#  include <arpa/nameser.h>
+#else
+#  include "nameser.h"
+#endif
+#ifdef HAVE_ARPA_NAMESER_COMPAT_H
+#  include <arpa/nameser_compat.h>
+#endif
+
+#include <stdlib.h>
+#include <string.h>
+#include "ares.h"
+#include "ares_dns.h"
+#include "ares_data.h"
+#include "ares_private.h"
+
+/* AIX portability check */
+#ifndef T_NAPTR
+	#define T_NAPTR 35 /* naming authority pointer */
+#endif
+
+int
+ares_parse_naptr_reply (const unsigned char *abuf, int alen,
+                        struct ares_naptr_reply **naptr_out)
+{
+  unsigned int qdcount, ancount, i;
+  const unsigned char *aptr, *vptr;
+  int status, rr_type, rr_class, rr_len;
+  long len;
+  char *hostname = NULL, *rr_name = NULL;
+  struct ares_naptr_reply *naptr_head = NULL;
+  struct ares_naptr_reply *naptr_last = NULL;
+  struct ares_naptr_reply *naptr_curr;
+
+  /* Set *naptr_out to NULL for all failure cases. */
+  *naptr_out = NULL;
+
+  /* Give up if abuf doesn't have room for a header. */
+  if (alen < HFIXEDSZ)
+    return ARES_EBADRESP;
+
+  /* Fetch the question and answer count from the header. */
+  qdcount = DNS_HEADER_QDCOUNT (abuf);
+  ancount = DNS_HEADER_ANCOUNT (abuf);
+  if (qdcount != 1)
+    return ARES_EBADRESP;
+  if (ancount == 0)
+    return ARES_ENODATA;
+
+  /* Expand the name from the question, and skip past the question. */
+  aptr = abuf + HFIXEDSZ;
+  status = ares_expand_name (aptr, abuf, alen, &hostname, &len);
+  if (status != ARES_SUCCESS)
+    return status;
+
+  if (aptr + len + QFIXEDSZ > abuf + alen)
+    {
+      free (hostname);
+      return ARES_EBADRESP;
+    }
+  aptr += len + QFIXEDSZ;
+
+  /* Examine each answer resource record (RR) in turn. */
+  for (i = 0; i < ancount; i++)
+    {
+      /* Decode the RR up to the data field. */
+      status = ares_expand_name (aptr, abuf, alen, &rr_name, &len);
+      if (status != ARES_SUCCESS)
+        {
+          break;
+        }
+      aptr += len;
+      if (aptr + RRFIXEDSZ > abuf + alen)
+        {
+          status = ARES_EBADRESP;
+          break;
+        }
+      rr_type = DNS_RR_TYPE (aptr);
+      rr_class = DNS_RR_CLASS (aptr);
+      rr_len = DNS_RR_LEN (aptr);
+      aptr += RRFIXEDSZ;
+
+      /* Check if we are really looking at a NAPTR record */
+      if (rr_class == C_IN && rr_type == T_NAPTR)
+        {
+          /* parse the NAPTR record itself */
+
+          /* Allocate storage for this NAPTR answer appending it to the list */
+          naptr_curr = ares_malloc_data(ARES_DATATYPE_NAPTR_REPLY);
+          if (!naptr_curr)
+            {
+              status = ARES_ENOMEM;
+              break;
+            }
+          if (naptr_last)
+            {
+              naptr_last->next = naptr_curr;
+            }
+          else
+            {
+              naptr_head = naptr_curr;
+            }
+          naptr_last = naptr_curr;
+
+          vptr = aptr;
+          naptr_curr->order = DNS__16BIT(vptr);
+          vptr += sizeof(unsigned short);
+          naptr_curr->preference = DNS__16BIT(vptr);
+          vptr += sizeof(unsigned short);
+
+          status = ares_expand_string(vptr, abuf, alen, &naptr_curr->flags, &len);
+          if (status != ARES_SUCCESS)
+            break;
+          vptr += len;
+
+          status = ares_expand_string(vptr, abuf, alen, &naptr_curr->service, &len);
+          if (status != ARES_SUCCESS)
+            break;
+          vptr += len;
+
+          status = ares_expand_string(vptr, abuf, alen, &naptr_curr->regexp, &len);
+          if (status != ARES_SUCCESS)
+            break;
+          vptr += len;
+
+          status = ares_expand_name(vptr, abuf, alen, &naptr_curr->replacement, &len);
+          if (status != ARES_SUCCESS)
+            break;
+        }
+
+      /* Don't lose memory in the next iteration */
+      free (rr_name);
+      rr_name = NULL;
+
+      /* Move on to the next record */
+      aptr += rr_len;
+    }
+
+  if (hostname)
+    free (hostname);
+  if (rr_name)
+    free (rr_name);
+
+  /* clean up on error */
+  if (status != ARES_SUCCESS)
+    {
+      if (naptr_head)
+        ares_free_data (naptr_head);
+      return status;
+    }
+
+  /* everything looks fine, return the data */
+  *naptr_out = naptr_head;
+
+  return ARES_SUCCESS;
+}
+

--- a/src/ares/ares_parse_ptr_reply.c
+++ b/src/ares/ares_parse_ptr_reply.c
@@ -42,6 +42,7 @@
 #include <string.h>
 #include "ares.h"
 #include "ares_dns.h"
+#include "ares_nowarn.h"
 #include "ares_private.h"
 
 int ares_parse_ptr_reply(const unsigned char *abuf, int alen, const void *addr,
@@ -189,8 +190,8 @@ int ares_parse_ptr_reply(const unsigned char *abuf, int alen, const void *addr,
                       for (i=0 ; i<aliascnt ; i++)
                         hostent->h_aliases[i] = aliases[i];
                       hostent->h_aliases[aliascnt] = NULL;
-                      hostent->h_addrtype = family;
-                      hostent->h_length = addrlen;
+                      hostent->h_addrtype = aresx_sitoss(family);
+                      hostent->h_length = aresx_sitoss(addrlen);
                       memcpy(hostent->h_addr_list[0], addr, addrlen);
                       hostent->h_addr_list[1] = NULL;
                       *host = hostent;

--- a/src/ares/ares_private.h
+++ b/src/ares/ares_private.h
@@ -342,7 +342,7 @@ long ares__tvdiff(struct timeval t1, struct timeval t2);
   do {                                                                  \
     if ((c)->sock_state_cb)                                             \
       (c)->sock_state_cb((c)->sock_state_cb_data, (s), (r), (w));       \
-  } while (0)
+  } WHILE_FALSE
 
 #ifdef CURLDEBUG
 /* This is low-level hard-hacking memory leak tracking and similar. Using the

--- a/src/ares/ares_process.c
+++ b/src/ares/ares_process.c
@@ -1,6 +1,6 @@
 
 /* Copyright 1998 by the Massachusetts Institute of Technology.
- * Copyright (C) 2004-2010 by Daniel Stenberg
+ * Copyright (C) 2004-2011 by Daniel Stenberg
  *
  * Permission to use, copy, modify, and distribute this
  * software and its documentation for any purpose and without
@@ -837,30 +837,29 @@ static int setsocknonblock(ares_socket_t sockfd,    /* operate on this */
 #elif defined(HAVE_IOCTL_FIONBIO)
 
   /* older unix versions */
-  int flags;
-  flags = nonblock;
+  int flags = nonblock ? 1 : 0;
   return ioctl(sockfd, FIONBIO, &flags);
 
 #elif defined(HAVE_IOCTLSOCKET_FIONBIO)
 
 #ifdef WATT32
-  char flags;
+  char flags = nonblock ? 1 : 0;
 #else
   /* Windows */
-  unsigned long flags;
+  unsigned long flags = nonblock ? 1UL : 0UL;
 #endif
-  flags = nonblock;
   return ioctlsocket(sockfd, FIONBIO, &flags);
 
 #elif defined(HAVE_IOCTLSOCKET_CAMEL_FIONBIO)
 
   /* Amiga */
-  return IoctlSocket(sockfd, FIONBIO, (long)nonblock);
+  long flags = nonblock ? 1L : 0L;
+  return IoctlSocket(sockfd, FIONBIO, flags);
 
 #elif defined(HAVE_SETSOCKOPT_SO_NONBLOCK)
 
   /* BeOS */
-  long b = nonblock ? 1 : 0;
+  long b = nonblock ? 1L : 0L;
   return setsockopt(sockfd, SOL_SOCKET, SO_NONBLOCK, &b, sizeof(b));
 
 #else

--- a/src/ares/ares_send.c
+++ b/src/ares/ares_send.c
@@ -77,7 +77,7 @@ void ares_send(ares_channel channel, const unsigned char *qbuf, int qlen,
     }
 
   /* Compute the query ID.  Start with no timeout. */
-  query->qid = (unsigned short)DNS_HEADER_QID(qbuf);
+  query->qid = DNS_HEADER_QID(qbuf);
   query->timeout.tv_sec = 0;
   query->timeout.tv_usec = 0;
 

--- a/src/ares/ares_setup.h
+++ b/src/ares/ares_setup.h
@@ -2,7 +2,7 @@
 #define HEADER_CARES_SETUP_H
 
 
-/* Copyright (C) 2004 - 2009 by Daniel Stenberg et al
+/* Copyright (C) 2004 - 2012 by Daniel Stenberg et al
  *
  * Permission to use, copy, modify, and distribute this software and its
  * documentation for any purpose and without fee is hereby granted, provided
@@ -76,6 +76,7 @@
 /* ================================================================ */
 
 #if 0 /* libuv hack */
+
 /*
  * c-ares external interface definitions are also used internally,
  * and might also include required system header files to define them.
@@ -88,6 +89,7 @@
  */
 
 #include <ares_rules.h>
+
 #endif /* libuv hack */
 
 /* ================================================================= */
@@ -158,6 +160,18 @@
 #endif
 
 #endif /* HAVE_CONFIG_H */
+
+/*
+ * Arg 2 type for gethostname in case it hasn't been defined in config file.
+ */
+
+#ifndef GETHOSTNAME_TYPE_ARG2
+#  ifdef USE_WINSOCK
+#    define GETHOSTNAME_TYPE_ARG2 int
+#  else
+#    define GETHOSTNAME_TYPE_ARG2 size_t
+#  endif
+#endif
 
 #ifdef __POCC__
 #  include <sys/types.h>

--- a/src/ares/config_cygwin/ares_config.h
+++ b/src/ares/config_cygwin/ares_config.h
@@ -448,7 +448,7 @@
 #define SIZEOF_INT 4
 
 /* The size of `long', as computed by sizeof. */
-#define SIZEOF_LONG 4
+#define CARES_SIZEOF_LONG 4
 
 /* The size of `size_t', as computed by sizeof. */
 #define SIZEOF_SIZE_T 4

--- a/src/ares/config_darwin/ares_config.h
+++ b/src/ares/config_darwin/ares_config.h
@@ -448,7 +448,10 @@
 #define SIZEOF_INT 4
 
 /* The size of `long', as computed by sizeof. */
-#define SIZEOF_LONG 4
+#define CARES_SIZEOF_LONG 4
+
+/* The size of `short', as computed by sizeof. */
+#define SIZEOF_SHORT 2
 
 /* The size of `size_t', as computed by sizeof. */
 #define SIZEOF_SIZE_T 4

--- a/src/ares/config_freebsd/ares_config.h
+++ b/src/ares/config_freebsd/ares_config.h
@@ -448,7 +448,7 @@
 #define SIZEOF_INT 4
 
 /* The size of `long', as computed by sizeof. */
-#define SIZEOF_LONG 4
+#define CARES_SIZEOF_LONG 4
 
 /* The size of `size_t', as computed by sizeof. */
 #define SIZEOF_SIZE_T 4

--- a/src/ares/config_linux/ares_config.h
+++ b/src/ares/config_linux/ares_config.h
@@ -448,7 +448,7 @@
 #define SIZEOF_INT 4
 
 /* The size of `long', as computed by sizeof. */
-#define SIZEOF_LONG 4
+#define CARES_SIZEOF_LONG 4
 
 /* The size of `size_t', as computed by sizeof. */
 #define SIZEOF_SIZE_T 4

--- a/src/ares/config_netbsd/ares_config.h
+++ b/src/ares/config_netbsd/ares_config.h
@@ -448,7 +448,7 @@
 #define SIZEOF_INT 4
 
 /* The size of `long', as computed by sizeof. */
-#define SIZEOF_LONG 4
+#define CARES_SIZEOF_LONG 4
 
 /* The size of `size_t', as computed by sizeof. */
 #define SIZEOF_SIZE_T 4

--- a/src/ares/config_openbsd/ares_config.h
+++ b/src/ares/config_openbsd/ares_config.h
@@ -448,7 +448,7 @@
 #define SIZEOF_INT 4
 
 /* The size of `long', as computed by sizeof. */
-#define SIZEOF_LONG 4
+#define CARES_SIZEOF_LONG 4
 
 /* The size of `size_t', as computed by sizeof. */
 #define SIZEOF_SIZE_T 4

--- a/src/ares/config_sunos/ares_config.h
+++ b/src/ares/config_sunos/ares_config.h
@@ -448,7 +448,7 @@
 #define SIZEOF_INT 4
 
 /* The size of `long', as computed by sizeof. */
-#define SIZEOF_LONG 4
+#define CARES_SIZEOF_LONG 4
 
 /* The size of `size_t', as computed by sizeof. */
 #define SIZEOF_SIZE_T 4

--- a/src/ares/config_win32/ares_config.h
+++ b/src/ares/config_win32/ares_config.h
@@ -365,5 +365,16 @@
 #define HAVE_SOCKADDR_IN6_SIN6_SCOPE_ID 1
 #endif
 
+/* ---------------------------------------------------------------- */
+/*                         SYSTEM ERROR CODES                       */
+/* ---------------------------------------------------------------- */
+
+#if defined(WIN32) && !defined(HAVE_ERRNO_H)
+#define ENOENT       ERROR_FILE_NOT_FOUND
+#define ESRCH        ERROR_PATH_NOT_FOUND
+#define ENOMEM       ERROR_NOT_ENOUGH_MEMORY
+#define ENOSPC       ERROR_INVALID_PARAMETER
+#endif
+
 
 #endif  /* __ARES_CONFIG_WIN32_H */

--- a/src/ares/config_win32/ares_config.h
+++ b/src/ares/config_win32/ares_config.h
@@ -233,6 +233,9 @@
 /* The size of `int', as computed by sizeof. */
 #define SIZEOF_INT 4
 
+/* The size of `long', as computed by sizeof. */
+#define CARES_SIZEOF_LONG 4
+
 /* The size of `short', as computed by sizeof. */
 #define SIZEOF_SHORT 2
 

--- a/src/ares/setup_once.h
+++ b/src/ares/setup_once.h
@@ -300,6 +300,27 @@ struct timeval {
 
 
 /*
+ * Macro WHILE_FALSE may be used to build single-iteration do-while loops,
+ * avoiding compiler warnings. Mostly intended for other macro definitions.
+ */
+
+#define WHILE_FALSE  while(0)
+
+#if defined(_MSC_VER) && !defined(__POCC__)
+#  undef WHILE_FALSE
+#  if (_MSC_VER < 1500)
+#    define WHILE_FALSE  while(1, 0)
+#  else
+#    define WHILE_FALSE \
+__pragma(warning(push)) \
+__pragma(warning(disable:4127)) \
+while(0) \
+__pragma(warning(pop))
+#  endif
+#endif
+
+
+/*
  * Typedef to 'int' if sig_atomic_t is not an available 'typedefed' type.
  */
 
@@ -336,7 +357,7 @@ typedef int sig_atomic_t;
 #ifdef DEBUGBUILD
 #define DEBUGF(x) x
 #else
-#define DEBUGF(x) do { } while (0)
+#define DEBUGF(x) do { } WHILE_FALSE
 #endif
 
 
@@ -347,7 +368,7 @@ typedef int sig_atomic_t;
 #if defined(DEBUGBUILD) && defined(HAVE_ASSERT_H)
 #define DEBUGASSERT(x) assert(x)
 #else
-#define DEBUGASSERT(x) do { } while (0)
+#define DEBUGASSERT(x) do { } WHILE_FALSE
 #endif
 
 
@@ -456,18 +477,6 @@ typedef int sig_atomic_t;
 #define EDQUOT           WSAEDQUOT
 #define ESTALE           WSAESTALE
 #define EREMOTE          WSAEREMOTE
-#endif
-
-
-/*
- *  System error codes for Windows CE
- */
-
-#if defined(WIN32) && !defined(HAVE_ERRNO_H)
-#define ENOENT       ERROR_FILE_NOT_FOUND
-#define ESRCH        ERROR_PATH_NOT_FOUND
-#define ENOMEM       ERROR_NOT_ENOUGH_MEMORY
-#define ENOSPC       ERROR_INVALID_PARAMETER
 #endif
 
 

--- a/uv.gyp
+++ b/uv.gyp
@@ -81,6 +81,7 @@
         'src/ares/ares_parse_aaaa_reply.c',
         'src/ares/ares_parse_a_reply.c',
         'src/ares/ares_parse_mx_reply.c',
+        'src/ares/ares_parse_naptr_reply.c',
         'src/ares/ares_parse_ns_reply.c',
         'src/ares/ares_parse_ptr_reply.c',
         'src/ares/ares_parse_srv_reply.c',


### PR DESCRIPTION
This PR updates c-ares to version 1.7.6-dev (current master at 41f8ff5). Diff looks bigger than it really is, quite some cosmetic changes were made upstream. This version also has support for NAPTR queries, which I particularly enjoy, and some other bugfixes.

All the changes that libuv used to apply to c-ares are also there.

When reviewing, please do check the changes on the platform headers, now SIZEOF_SHORT and CARES_SIZEOF_LONG need to be defined, hopefully I got them right.

I did test this code (all ares_gethost_, ares_getaddr_ and query functions) on Windows (7, 32bits) and Darwin and I'll check Linux later today, but I don't have access to other BSD flavors nor SunOS, sorry!
