### PR TITLE
Implement uid/gid argument to uv_spawn

### DIFF
--- a/include/uv.h
+++ b/include/uv.h
@@ -1111,14 +1111,14 @@ typedef struct uv_process_options_s {
    * setgid to before executing.
    * Unix only.
    */
-  int gid;
+  gid_t gid;
 
   /*
    * If not -1, this represents the user ID that the subprocess should
    * setuid to before executing.
    * Unix only.
    */
-  int uid;
+  uid_t uid;
 
   /*
    * TODO describe how this works.

--- a/include/uv.h
+++ b/include/uv.h
@@ -1107,6 +1107,20 @@ typedef struct uv_process_options_s {
   char* cwd;
 
   /*
+   * If not -1, this represents the group ID that the subprocess should
+   * setgid to before executing.
+   * Unix only.
+   */
+  int gid;
+
+  /*
+   * If not -1, this represents the user ID that the subprocess should
+   * setuid to before executing.
+   * Unix only.
+   */
+  int uid;
+
+  /*
    * TODO describe how this works.
    */
   int windows_verbatim_arguments;

--- a/src/unix/process.c
+++ b/src/unix/process.c
@@ -263,12 +263,12 @@ int uv_spawn(uv_loop_t* loop, uv_process_t* process,
       _exit(127);
     }
 
-    if (options.gid && options.gid != -1 && setgid(options.gid)) {
+    if (options.gid != (gid_t)(-1) && setgid(options.gid)) {
       perror("setgid()");
       _exit(127);
     }
 
-    if (options.uid && options.uid != -1 && setuid(options.uid)) {
+    if (options.uid != (uid_t)(-1) && setuid(options.uid)) {
       perror("setuid()");
       _exit(127);
     }

--- a/src/unix/process.c
+++ b/src/unix/process.c
@@ -263,6 +263,16 @@ int uv_spawn(uv_loop_t* loop, uv_process_t* process,
       _exit(127);
     }
 
+    if (options.gid && options.gid != -1 && setgid(options.gid)) {
+      perror("setgid()");
+      _exit(127);
+    }
+
+    if (options.uid && options.uid != -1 && setuid(options.uid)) {
+      perror("setuid()");
+      _exit(127);
+    }
+
     environ = options.env;
 
     execvp(options.file, options.args);

--- a/test/test-spawn.c
+++ b/test/test-spawn.c
@@ -119,8 +119,8 @@ static void init_process_options(char* test, uv_exit_cb exit_cb) {
   options.file = exepath;
   options.args = args;
   options.exit_cb = exit_cb;
-  options.uid = -1;
-  options.gid = -1;
+  options.uid = (uid_t)(-1);
+  options.gid = (gid_t)(-1);
 }
 
 


### PR DESCRIPTION
This is necessary to replace the uid/gid arguments to child_process.spawn in Node, which apparently started silently not working as of 0.6.
