### PR TITLE
remove a meaningless code and cleanup a warning

### DIFF
--- a/src/unix/linux/syscalls.c
+++ b/src/unix/linux/syscalls.c
@@ -132,12 +132,13 @@
 
 int uv__accept4(int fd, struct sockaddr* addr, socklen_t* addrlen, int flags) {
 #if __i386__
-  unsigned long args[] = {
-    (unsigned long) fd,
-    (unsigned long) addr,
-    (unsigned long) addrlen,
-    (unsigned long) flags
-  };
+  unsigned long args[4];
+
+  args[0] = fd;
+  args[1] = (unsigned long) addr;
+  args[2] = (unsigned long) addrlen;
+  args[3] = flags;
+
   return syscall(__NR_socketcall, 18 /* SYS_ACCEPT4 */, args);
 #elif __NR_accept4
   return syscall(__NR_accept4, fd, addr, addrlen, flags);

--- a/src/unix/pipe.c
+++ b/src/unix/pipe.c
@@ -180,7 +180,6 @@ void uv_pipe_connect(uv_connect_t* req,
   int r;
 
   saved_errno = errno;
-  sockfd = -1;
   status = -1;
 
   if ((sockfd = uv__socket(AF_UNIX, SOCK_STREAM, 0)) == -1) {


### PR DESCRIPTION
1 remove meaningless init of sockfd in uv_pipe_connect

2 remove compile warning(initializer element is not computable at load time) in uv__accept4, because initializer array must be constant compile time expressions in c89.
