### PR TITLE
fix build on mingw32.

### DIFF
--- a/src/win/winapi.h
+++ b/src/win/winapi.h
@@ -23,6 +23,9 @@
 #define UV_WIN_WINAPI_H_
 
 #include <windows.h>
+#ifdef __MINGW32__
+#include <ntdef.h>
+#endif
 
 
 /*


### PR DESCRIPTION
on mingw32, NTSTATUS is defined in ntdef.h
