### PR TITLE
Change #if FIONBIO to #ifdef FIONBIO.

### DIFF
--- a/src/unix/core.c
+++ b/src/unix/core.c
@@ -480,7 +480,7 @@ int uv__accept(int sockfd, struct sockaddr* saddr, socklen_t slen) {
 
 
 int uv__nonblock(int fd, int set) {
-#if FIONBIO
+#ifdef FIONBIO
   return ioctl(fd, FIONBIO, &set);
 #else
   int flags;


### PR DESCRIPTION
Fixes compilation on Debian/ppc 6.0.4.
