### PR TITLE
Fix compilation with MingW: NTSTATUS & PNTSTATUS were redefined.

### DIFF
--- a/include/uv-private/uv-win.h
+++ b/include/uv-private/uv-win.h
@@ -134,6 +134,7 @@ typedef int (WSAAPI* LPFN_WSARECVFROM)
              LPWSAOVERLAPPED_COMPLETION_ROUTINE completion_routine);
 
 #ifndef _NTDEF_
+#define _NTDEF_ 1
   typedef LONG NTSTATUS;
   typedef NTSTATUS *PNTSTATUS;
 #endif


### PR DESCRIPTION
Once in uv-win.h, then in winapi.h
