### PR TITLE
Support uv_interface_addresses on SunOS

### DIFF
--- a/src/unix/sunos.c
+++ b/src/unix/sunos.c
@@ -28,9 +28,7 @@
 #include <assert.h>
 #include <errno.h>
 
-#ifdef SUNOS_HAVE_IFADDRS
-# include <ifaddrs.h>
-#endif
+#include <ifaddrs.h>
 #include <net/if.h>
 
 #include <sys/loadavg.h>
@@ -407,9 +405,7 @@ void uv_free_cpu_info(uv_cpu_info_t* cpu_infos, int count) {
 
 uv_err_t uv_interface_addresses(uv_interface_address_t** addresses,
   int* count) {
-#ifndef SUNOS_HAVE_IFADDRS
-  return uv__new_artificial_error(UV_ENOSYS);
-#else
+
   struct ifaddrs *addrs, *ent;
   char ip[INET6_ADDRSTRLEN];
   uv_interface_address_t* address;
@@ -466,7 +462,6 @@ uv_err_t uv_interface_addresses(uv_interface_address_t** addresses,
   freeifaddrs(addrs);
 
   return uv_ok_;
-#endif  /* SUNOS_HAVE_IFADDRS */
 }
 
 


### PR DESCRIPTION
Hello,

The Node.js `require('os').networkInterfaces()` is broken on Illumos (i.e., Solaris), and digging into the code, it's all there, but was #ifdef'd out, presumably because it was unclear if `getifaddrs` was available. `getifadds` is available on Illumos platforms (it seems it has been since late OpenSolaris days).  This PR simply #ifdef's out that code.  Running from node on smartos now spits out:

```
console.log(JSON.stringify(os.networkInterfaces(), null, 4))
{
   "lo0": [
       {
           "address": "127.0.0.1",
           "family": "IPv4",
           "internal": true
       },
       {
           "address": "::1",
           "family": "IPv6",
           "internal": true
       }
   ],
   "net0": [
       {
           "address": "10.88.88.130",
           "family": "IPv4",
           "internal": false
       }
   ]
}
```
