### PR TITLE
Added missing include for limits.h

### DIFF
--- a/src/win/util.c
+++ b/src/win/util.c
@@ -21,6 +21,7 @@
 
 #include <assert.h>
 #include <direct.h>
+#include <limits.h>
 #include <malloc.h>
 #include <stdio.h>
 #include <string.h>


### PR DESCRIPTION
I'm not sure if this is required when compiling with Visual Studio, but it is when using MinGW.
