### PR TITLE
Implement uv_loop_get_backend_fd()

### DIFF
--- a/include/uv-private/ev.h
+++ b/include/uv-private/ev.h
@@ -598,6 +598,8 @@ void ev_loop_fork (EV_P);
 
 unsigned int ev_backend (EV_P); /* backend in use by loop */
 
+int ev_backend_fd(EV_P); /* backend file descriptor */
+
 void ev_now_update (EV_P); /* update event loop time */
 
 #if EV_WALK_ENABLE

--- a/include/uv.h
+++ b/include/uv.h
@@ -224,6 +224,11 @@ UV_EXTERN uv_loop_t* uv_loop_new(void);
 UV_EXTERN void uv_loop_delete(uv_loop_t*);
 
 /*
+ * Returns the loop file descriptor on Unix. On Windows, always return -1.
+ */
+UV_EXTERN int uv_loop_get_backend_fd(uv_loop_t*);
+
+/*
  * Returns the default loop.
  */
 UV_EXTERN uv_loop_t* uv_default_loop(void);

--- a/src/unix/core.c
+++ b/src/unix/core.c
@@ -214,6 +214,11 @@ uv_loop_t* uv_loop_new(void) {
 }
 
 
+int uv_loop_get_backend_fd(uv_loop_t* loop) {
+  return ev_backend_fd(loop->ev);
+}
+
+
 void uv_loop_delete(uv_loop_t* loop) {
   uv__loop_delete(loop);
 #ifndef NDEBUG

--- a/src/unix/ev/ev++.h
+++ b/src/unix/ev/ev++.h
@@ -226,6 +226,11 @@ namespace ev {
       return ev_backend (EV_AX);
     }
 
+    int backend_fd () const
+    {
+      return ev_backend_fd(EV_AX);
+    }
+
     tstamp now () const throw ()
     {
       return ev_now (EV_AX);

--- a/src/unix/ev/ev.c
+++ b/src/unix/ev/ev.c
@@ -1625,6 +1625,11 @@ ev_backend (EV_P)
   return backend;
 }
 
+int ev_backend_fd(EV_P)
+{
+  return backend_fd;
+}
+
 #if EV_FEATURE_API
 unsigned int
 ev_iteration (EV_P)

--- a/src/win/core.c
+++ b/src/win/core.c
@@ -141,6 +141,11 @@ uv_loop_t* uv_loop_new(void) {
 }
 
 
+int uv_loop_get_backend_fd(uv_loop_t* loop) {
+  return -1;
+}
+
+
 void uv_loop_delete(uv_loop_t* loop) {
   if (loop != &uv_default_loop_) {
     int i;


### PR DESCRIPTION
This allows obtaining the poller file descriptor for backends that support
it (mainly epoll under Linux and kqueue under *BSD); other backends (such as
the Windows one) will return -1.

This can be used to integrate with other main loops (such as EFL's Ecore or
Glib's).
