### PR TITLE
Wrong compiler opiton in Makefile

### DIFF
--- a/config-unix.mk
+++ b/config-unix.mk
@@ -19,7 +19,7 @@
 # IN THE SOFTWARE.
 
 E=
-CSTDFLAG=--std=c89 -pedantic -Wall -Wextra -Wno-unused-parameter
+CSTDFLAG=-std=c89 -pedantic -Wall -Wextra -Wno-unused-parameter
 CFLAGS += -g
 CPPFLAGS += -Isrc -Isrc/unix/ev
 LINKFLAGS=-lm


### PR DESCRIPTION
gcc / clang doesn't have --std option. Use -std instead.
