### PR TITLE
fs test fixes

### DIFF
--- a/test/runner-unix.c
+++ b/test/runner-unix.c
@@ -40,6 +40,11 @@
 
 /* Do platform-specific initialization. */
 void platform_init(int argc, char **argv) {
+  /* Running the tests as root is not smart - don't do it. */
+  if (getuid() == 0) {
+    fprintf(stderr, "Running the tests as root is not safe.\n");
+    exit(1);
+  }
   /* Disable stdio output buffering. */
   setvbuf(stdout, NULL, _IONBF, 0);
   setvbuf(stderr, NULL, _IONBF, 0);


### PR DESCRIPTION
These are some minor test improvements that will prevent unneeded test failures moving forward.

The file watching tests in `test-fs-events.c` all use the same directory for their fixtures - `watch_dir`.  If a test fails from an assertion error, it doesn't clean up, and this can cause other tests to fail, simply due to the other tests trying to rmdir("watch_dir") when there are still other files left in the directory.  I've replaced the repetitive and not always accurate manual cleanups with a helper method, `cleanup_watch_dir`, that reads the directory first, and cleans up whatever is actually there.

I added a second commit to skip one of the `uv_fs_chown` test cases if the tests are being run as root.  The test expects to fail - a normal user can't `chown` something to root - but if the current uid is 0, it succeeds, which makes the test fail.  This seemed spurious.
