### PR TITLE
Allow suppression of ifaddrs.h on SunOS

### DIFF
--- a/src/unix/sunos.c
+++ b/src/unix/sunos.c
@@ -28,7 +28,9 @@
 #include <assert.h>
 #include <errno.h>
 
-#include <ifaddrs.h>
+#ifndef SUNOS_NO_IFADDRS
+# include <ifaddrs.h>
+#endif
 #include <net/if.h>
 
 #include <sys/loadavg.h>
@@ -405,7 +407,9 @@ void uv_free_cpu_info(uv_cpu_info_t* cpu_infos, int count) {
 
 uv_err_t uv_interface_addresses(uv_interface_address_t** addresses,
   int* count) {
-
+#ifdef SUNOS_NO_IFADDRS
+  return uv__new_artificial_error(UV_ENOSYS);
+#else
   struct ifaddrs *addrs, *ent;
   char ip[INET6_ADDRSTRLEN];
   uv_interface_address_t* address;
@@ -462,6 +466,7 @@ uv_err_t uv_interface_addresses(uv_interface_address_t** addresses,
   freeifaddrs(addrs);
 
   return uv_ok_;
+#endif  /* SUNOS_NO_IFADDRS */
 }
 
 


### PR DESCRIPTION
Older Solaris versions do not have this feature.  This allows
them to set SUNOS_NO_IFADDRS to allow libuv to build.

Re: joyent/node#3465
