### PR TITLE
unix: don't abort uv_mutex_trylock when it returns EDEADLK or EBUSY.

### DIFF
--- a/src/unix/thread.c
+++ b/src/unix/thread.c
@@ -78,7 +78,7 @@ int uv_mutex_trylock(uv_mutex_t* mutex) {
 
   r = pthread_mutex_trylock(mutex);
 
-  if (r && (r != EDEADLK && r != EBUSY && r != EAGAIN))
+  if (r && r != EBUSY && r != EAGAIN)
     abort();
 
   if (r)
@@ -119,7 +119,7 @@ int uv_rwlock_tryrdlock(uv_rwlock_t* rwlock) {
 
   r = pthread_rwlock_tryrdlock(rwlock);
 
-  if (r && r != EAGAIN)
+  if (r && r != EBUSY && r != EAGAIN)
     abort();
 
   if (r)
@@ -146,7 +146,7 @@ int uv_rwlock_trywrlock(uv_rwlock_t* rwlock) {
 
   r = pthread_rwlock_trywrlock(rwlock);
 
-  if (r && r != EAGAIN)
+  if (r && r != EBUSY && r != EAGAIN)
     abort();
 
   if (r)

--- a/src/unix/thread.c
+++ b/src/unix/thread.c
@@ -78,7 +78,7 @@ int uv_mutex_trylock(uv_mutex_t* mutex) {
 
   r = pthread_mutex_trylock(mutex);
 
-  if (r && r != EAGAIN)
+  if (r && (r != EDEADLK && r != EBUSY && r != EAGAIN))
     abort();
 
   if (r)

--- a/test/test-mutexes.c
+++ b/test/test-mutexes.c
@@ -39,6 +39,8 @@ TEST_IMPL(thread_mutex) {
   ASSERT(r == 0);
 
   uv_mutex_lock(&mutex);
+  r = uv_mutex_trylock(&mutex);
+  ASSERT(r == -1);
   uv_mutex_unlock(&mutex);
   uv_mutex_destroy(&mutex);
 

--- a/test/test-mutexes.c
+++ b/test/test-mutexes.c
@@ -39,8 +39,6 @@ TEST_IMPL(thread_mutex) {
   ASSERT(r == 0);
 
   uv_mutex_lock(&mutex);
-  r = uv_mutex_trylock(&mutex);
-  ASSERT(r == -1);
   uv_mutex_unlock(&mutex);
   uv_mutex_destroy(&mutex);
 


### PR DESCRIPTION
`uv_mutex_trylock` only checks `EAGAIN`. this changes accepts `EDEADLK` and `EBUSY` errors.

Basically, `EDEADLK` only cause on same thread. I'm not sure I should add this error check here.
But this changes would be helpful in some cases (i. e single thread application). I would be glad if this is accepted.

Thanks,
