### PR TITLE
Including <uv.h> shouldn't emit any warnings

### DIFF
--- a/include/uv-private/eio.h
+++ b/include/uv-private/eio.h
@@ -251,7 +251,7 @@ struct eio_req
 
   eio_channel *channel; /* data used to direct poll callbacks arising from this req */
 
-#if __i386 || __amd64
+#if defined(__i386) || defined(__amd64)
   unsigned char cancelled;
 #else
   sig_atomic_t cancelled;

--- a/include/uv-private/ngx-queue.h
+++ b/include/uv-private/ngx-queue.h
@@ -62,7 +62,7 @@ struct ngx_queue_s {
     (q)->prev
 
 
-#if (NGX_DEBUG)
+#if defined(NGX_DEBUG)
 
 #define ngx_queue_remove(x)                                                   \
     (x)->next->prev = (x)->prev;                                              \

--- a/include/uv-private/uv-unix.h
+++ b/include/uv-private/uv-unix.h
@@ -51,7 +51,7 @@
 # include <semaphore.h>
 #endif
 
-#if __sun
+#if defined(__sun)
 # include <sys/port.h>
 # include <port.h>
 #endif
@@ -103,7 +103,7 @@ struct uv__io_s {
 
 #define UV_REQ_TYPE_PRIVATE /* empty */
 
-#if __linux__
+#if defined(__linux__)
 # define UV_LOOP_PRIVATE_PLATFORM_FIELDS              \
   uv__io_t inotify_read_watcher;                      \
   void* inotify_watchers;                             \

--- a/include/uv.h
+++ b/include/uv.h
@@ -53,6 +53,10 @@ extern "C" {
 #include <stdint.h> /* int64_t */
 #include <sys/types.h> /* size_t */
 
+#if defined(__SVR4) && !defined(__unix__)
+#define __unix__
+#endif
+
 #if defined(__unix__) || defined(__POSIX__) || defined(__APPLE__)
 # include "uv-private/uv-unix.h"
 #else


### PR DESCRIPTION
I'm trying to add a plugin that use libuv to my library and I'm normally compiling my modules with:

 gcc -DHAVE_CONFIG_H -I. -I./src -pipe -I./include -DHAVE_VISIBILITY=1 -fvisibility=hidden -Wall -pedantic -Wundef -Wshadow -fdiagnostics-show-option -Wformat -fno-strict-aliasing -Wno-strict-aliasing -Wextra -Werror -fprofile-arcs -ftest-coverage -pipe -std=gnu99 -Wstrict-prototypes -Wmissing-prototypes -Wredundant-decls -Wmissing-declarations -Wcast-align 

The constructs:
# if variable

will emit a warning if it's not defined, causing my build to break. The attached patch change these to #ifdef (this means that defining them to "0" instead of undef'ing them no longer works.. The alternative would be to extend the code check if they're defined _AND_ set to something else than 0...
