### PR TITLE
Implemented uv_run2 (adding flags to uv_run)

### DIFF
--- a/include/uv.h
+++ b/include/uv.h
@@ -221,6 +221,13 @@ typedef struct uv_cpu_info_s uv_cpu_info_t;
 typedef struct uv_interface_address_s uv_interface_address_t;
 
 
+typedef enum {
+  UV_RUN_DEFAULT = 0,
+  UV_RUN_ONCE,
+  UV_RUN_NOWAIT
+} uv_run_mode;
+
+
 /*
  * This function must be called before any other functions in libuv.
  *
@@ -244,12 +251,18 @@ UV_EXTERN uv_loop_t* uv_default_loop(void);
 UV_EXTERN int uv_run(uv_loop_t*);
 
 /*
- * Poll for new events once. Note that this function blocks if there are no
- * pending events. Returns zero when done (no active handles or requests left),
- * or non-zero if more events are expected (meaning you should call
- * uv_run_once() again sometime in the future).
+ * This function runs the event loop. It will act differently depending on the
+ * specified mode:
+ *  - UV_RUN_DEFAULT: Runs the event loop until the reference count drops to
+ *    zero. Always returns zero.
+ *  - UV_RUN_ONCE: Poll for new events once. Note that this function blocks if
+ *    there are no pending events. Returns zero when done (no active handles
+ *    or requests left), or non-zero if more events are expected (meaning you
+ *    should run the event loop again sometime in the future).
+ *  - UV_RUN_NOWAIT: Poll for new events once but don't block if there are no
+ *    pending events.
  */
-UV_EXTERN int uv_run_once(uv_loop_t*);
+UV_EXTERN int uv_run2(uv_loop_t*, uv_run_mode mode);
 
 /*
  * Manually modify the event loop's reference count. Useful if the user wants

--- a/src/win/core.c
+++ b/src/win/core.c
@@ -252,57 +252,47 @@ static void uv_poll_ex(uv_loop_t* loop, int block) {
      !ngx_queue_empty(&(loop)->active_reqs) ||                                \
      (loop)->endgame_handles != NULL)
 
-#define UV_LOOP_ONCE(loop, poll)                                              \
-  do {                                                                        \
-    uv_update_time((loop));                                                   \
-    uv_process_timers((loop));                                                \
-                                                                              \
-    /* Call idle callbacks if nothing to do. */                               \
-    if ((loop)->pending_reqs_tail == NULL &&                                  \
-        (loop)->endgame_handles == NULL) {                                    \
-      uv_idle_invoke((loop));                                                 \
-    }                                                                         \
-                                                                              \
-    uv_process_reqs((loop));                                                  \
-    uv_process_endgames((loop));                                              \
-                                                                              \
-    if (!UV_LOOP_ALIVE((loop))) {                                             \
-      break;                                                                  \
-    }                                                                         \
-                                                                              \
-    uv_prepare_invoke((loop));                                                \
-                                                                              \
-    poll((loop), (loop)->idle_handles == NULL &&                              \
-                 (loop)->pending_reqs_tail == NULL &&                         \
-                 (loop)->endgame_handles == NULL &&                           \
-                 UV_LOOP_ALIVE((loop)));                                      \
-                                                                              \
-    uv_check_invoke((loop));                                                  \
-  } while (0);
+int uv_run2(uv_loop_t *loop, uv_run_mode mode) {
+  int r;
+  void (*poll)(uv_loop_t* loop, int block);
 
-#define UV_LOOP(loop, poll)                                                   \
-  while (UV_LOOP_ALIVE((loop))) {                                             \
-    UV_LOOP_ONCE(loop, poll)                                                  \
+  if (pGetQueuedCompletionStatusEx)
+    poll = &uv_poll_ex;
+  else:
+    poll = &uv_poll;
+
+  r = UV_LOOP_ALIVE(loop);
+  while (r) {
+    uv_update_time(loop);
+    uv_process_timers(loop);
+
+    /* Call idle callbacks if nothing to do. */
+    if (loop->pending_reqs_tail == NULL &&
+        loop->endgame_handles == NULL) {
+      uv_idle_invoke(loop);
+    }
+
+    uv_process_reqs(loop);
+    uv_process_endgames(loop);
+
+    uv_prepare_invoke(loop);
+
+    (*poll)(loop, loop->idle_handles == NULL &&
+                  loop->pending_reqs_tail == NULL &&
+                  loop->endgame_handles == NULL &&
+                  UV_LOOP_ALIVE(loop) &&
+                  !(mode & UV_RUN_NOWAIT));
+
+    uv_check_invoke(loop);
+    r = UV_LOOP_ALIVE(loop);
+
+    if (mode & (UV_RUN_ONCE | UV_RUN_NOWAIT))
+      break;
   }
-
-
-int uv_run_once(uv_loop_t* loop) {
-  if (pGetQueuedCompletionStatusEx) {
-    UV_LOOP_ONCE(loop, uv_poll_ex);
-  } else {
-    UV_LOOP_ONCE(loop, uv_poll);
-  }
-  return UV_LOOP_ALIVE(loop);
+  return r;
 }
 
 
 int uv_run(uv_loop_t* loop) {
-  if (pGetQueuedCompletionStatusEx) {
-    UV_LOOP(loop, uv_poll_ex);
-  } else {
-    UV_LOOP(loop, uv_poll);
-  }
-
-  assert(!UV_LOOP_ALIVE((loop)));
-  return 0;
+  return uv_run2(loop, UV_RUN_DEFAULT);
 }

--- a/test/test-embed.c
+++ b/test/test-embed.c
@@ -84,7 +84,7 @@ static void embed_thread_runner(void* arg) {
 
 
 static void embed_cb(uv_async_t* async, int status) {
-  uv_run_once(uv_default_loop());
+  uv_run2(uv_default_loop(), UV_RUN_ONCE);
 
   uv_sem_post(&embed_sem);
 }

--- a/test/test-list.h
+++ b/test/test-list.h
@@ -22,6 +22,7 @@
 TEST_DECLARE   (platform_output)
 TEST_DECLARE   (callback_order)
 TEST_DECLARE   (run_once)
+TEST_DECLARE   (run_nowait)
 TEST_DECLARE   (barrier_1)
 TEST_DECLARE   (barrier_2)
 TEST_DECLARE   (barrier_3)
@@ -222,6 +223,7 @@ TASK_LIST_START
   TEST_ENTRY  (callback_order)
 #endif
   TEST_ENTRY  (run_once)
+  TEST_ENTRY  (run_nowait)
   TEST_ENTRY  (barrier_1)
   TEST_ENTRY  (barrier_2)
   TEST_ENTRY  (barrier_3)

--- a/uv.gyp
+++ b/uv.gyp
@@ -275,6 +275,7 @@
         'test/test-poll-close.c',
         'test/test-process-title.c',
         'test/test-ref.c',
+        'test/test-run-nowait.c',
         'test/test-run-once.c',
         'test/test-semaphore.c',
         'test/test-shutdown-close.c',


### PR DESCRIPTION
Allows for running the event loop in 3 modes:
- default: loop runs until the refcount drops to zero
- once: poll for events only once and block until one is handled
- nowait: poll for events only once but don't block if there are
  no pending events

The patch contains the Unix implementation, I'll do the Windows one after some initial feedback.

I thought changing uv_run could be a bit too much, so the new functionality is implemented as uv_run2. I did remove uv_run_once, since it's very straightforward to mock with a define, for software which runs on 0.8 and 0.9.

Related issue: #339

/cc @bnoordhuis @piscisaureus
