### PR TITLE
unix: map errno EDQUOT

### DIFF
--- a/src/unix/error.c
+++ b/src/unix/error.c
@@ -102,6 +102,7 @@ uv_err_code uv_translate_sys_error(int sys_errno) {
     case ENOSPC: return UV_ENOSPC;
     case EROFS: return UV_EROFS;
     case ENOMEM: return UV_ENOMEM;
+    case EDQUOT: return UV_ENOSPC;
     default: return UV_UNKNOWN;
   }
   UNREACHABLE();


### PR DESCRIPTION
Encountered this as an 'unknown error' in node when the disk limit on a smartOS zone was hit.
