### PR TITLE
unix: map `EDQUOT` to `UV_EDQUOT`

### DIFF
--- a/include/uv.h
+++ b/include/uv.h
@@ -123,6 +123,7 @@ extern "C" {
   XX( 56, EROFS, "read-only file system") \
   XX( 57, ENODEV, "no such device") \
   XX( 58, ESPIPE, "invalid seek") \
+  XX( 59, EDQUOT, "disk quota exceeded") \
 
 
 #define UV_ERRNO_GEN(val, name, s) UV_##name = val,

--- a/src/unix/error.c
+++ b/src/unix/error.c
@@ -100,6 +100,7 @@ uv_err_code uv_translate_sys_error(int sys_errno) {
     case ENOSPC: return UV_ENOSPC;
     case EROFS: return UV_EROFS;
     case ENOMEM: return UV_ENOMEM;
+    case EDQUOT: return UV_EDQUOT;
     default: return UV_UNKNOWN;
   }
   UNREACHABLE();


### PR DESCRIPTION
Seen in production on a SmartOS machine.
