### PR TITLE
Implement uv_set_process_title on darwin. Just copied linux implementati...

### DIFF
--- a/src/unix/darwin.c
+++ b/src/unix/darwin.c
@@ -41,7 +41,12 @@
 #include <sys/sysctl.h>
 #include <unistd.h>  /* sysconf */
 
-static char *process_title;
+static void* args_mem;
+
+static struct {
+  char *str;
+  size_t len;
+} process_title;
 
 /* Forward declarations */
 void uv__cf_loop_runner(void* arg);
@@ -273,20 +278,64 @@ void uv_loadavg(double avg[3]) {
 
 
 char** uv_setup_args(int argc, char** argv) {
-  process_title = argc ? strdup(argv[0]) : NULL;
-  return argv;
+  extern char **environ;
+  char **new_argv;
+  char **new_env;
+  size_t size;
+  int envc;
+  char *s;
+  int i;
+
+  for (envc = 0; environ[envc]; envc++);
+
+  s = envc ? environ[envc - 1] : argv[argc - 1];
+
+  process_title.str = argv[0];
+  process_title.len = s + strlen(s) + 1 - argv[0];
+
+  size = process_title.len;
+  size += (argc + 1) * sizeof(char **);
+  size += (envc + 1) * sizeof(char **);
+
+  if (NULL == (s = malloc(size))) {
+    process_title.str = NULL;
+    process_title.len = 0;
+    return argv;
+  }
+  args_mem = s;
+
+  new_argv = (char **) s;
+  new_env = new_argv + argc + 1;
+  s = (char *) (new_env + envc + 1);
+  memcpy(s, process_title.str, process_title.len);
+
+  for (i = 0; i < argc; i++)
+    new_argv[i] = s + (argv[i] - argv[0]);
+  new_argv[argc] = NULL;
+
+  s += environ[0] - argv[0];
+
+  for (i = 0; i < envc; i++)
+    new_env[i] = s + (environ[i] - environ[0]);
+  new_env[envc] = NULL;
+
+  environ = new_env;
+  return new_argv;
 }
 
 
 uv_err_t uv_set_process_title(const char* title) {
-  /* TODO implement me */
-  return uv__new_artificial_error(UV_ENOSYS);
+  /* No need to terminate, last char is always '\0'. */
+  if (process_title.len)
+    strncpy(process_title.str, title, process_title.len - 1);
+
+  return uv_ok_;
 }
 
 
 uv_err_t uv_get_process_title(char* buffer, size_t size) {
-  if (process_title) {
-    strncpy(buffer, process_title, size);
+  if (process_title.str) {
+    strncpy(buffer, process_title.str, size);
   } else {
     if (size > 0) {
       buffer[0] = '\0';


### PR DESCRIPTION
...on and add 'extern char **environ'.

I found a library named libnostd impelemnts setproctitle on darwin.
http://www.25thandclement.com/~william/projects/libnostd.html
Its implemetaion is almost same between linux and darwin, so I copied libuv linux implementation of uv_set_process_title to src/unix/darwin.c

I confirmed all tests pass on darwin with this pull request applied.

I also tried a sample program using uv_set_process_title.

libuv_set_process_title_test.c

```
#include <stdio.h>
#include <unistd.h>
#include <uv.h>

int main(int argc, char **argv) {
  char buffer[256];

  argv = uv_setup_args(argc, argv);

  if (argc > 1)
    uv_set_process_title("hello uv_set_process_title");

  uv_get_process_title(buffer, sizeof(buffer));
  printf("title=%s\n", buffer);

  sleep(2);
  return 0;
}
```

The results:

```
c -o a.out libuv_set_process_title_test.c -I $(HOME)/src/libuv/include -L $(HOME)/src/libuv -luv -framework CoreServices
bash-3.2$ ./a.out & ps auxww | grep 'hello uv_set_process_title' | grep -v grep
[1] 24982
title=./a.out
bash-3.2$ 
[1]+  Done                    ./a.out
bash-3.2$ ./a.out 1 & ps auxww | grep 'hello uv_set_process_title' | grep -v grep
[1] 24986
title=hello uv_set_process_title
hnakamur       24986   0.0  0.0  2433000   1148 s006  R     7:55AM   0:00.01 hello uv_set_process_title 
```
