### PR TITLE
Add UV_PROCESS_WINDOWS_HIDE to avoid consoles on Windows

### DIFF
--- a/include/uv.h
+++ b/include/uv.h
@@ -1314,7 +1314,12 @@ enum uv_process_flags {
    * parent's event loop alive unless the parent process calls uv_unref() on
    * the child's process handle.
    */
-  UV_PROCESS_DETACHED = (1 << 3)
+  UV_PROCESS_DETACHED = (1 << 3),
+  /*
+   * Hide the subprocess console window that would normally be created. This 
+   * option is only meaningful on Windows systems. On unix it is silently ignored.
+   */
+  UV_PROCESS_WINDOWS_HIDE = (1 << 4)
 };
 
 /*

--- a/src/win/process.c
+++ b/src/win/process.c
@@ -777,7 +777,8 @@ int uv_spawn(uv_loop_t* loop, uv_process_t* process,
   }
 
   assert(options.file != NULL);
-  assert(!(options.flags & ~(UV_PROCESS_WINDOWS_VERBATIM_ARGUMENTS |
+  assert(!(options.flags & ~(UV_PROCESS_WINDOWS_HIDE |
+                             UV_PROCESS_WINDOWS_VERBATIM_ARGUMENTS |
                              UV_PROCESS_DETACHED |
                              UV_PROCESS_SETGID |
                              UV_PROCESS_SETUID)));
@@ -872,7 +873,13 @@ int uv_spawn(uv_loop_t* loop, uv_process_t* process,
   startup.lpReserved = NULL;
   startup.lpDesktop = NULL;
   startup.lpTitle = NULL;
-  startup.dwFlags = STARTF_USESTDHANDLES;
+  startup.dwFlags = STARTF_USESTDHANDLES|STARTF_USESHOWWINDOW;
+  if (options.flags & UV_PROCESS_WINDOWS_HIDE) {
+    /* Use SW_HIDE to avoid any potential process window */
+    startup.wShowWindow = SW_HIDE;
+  } else {
+    startup.wShowWindow = SW_SHOWDEFAULT;
+  }
   startup.cbReserved2 = uv__stdio_size(process->child_stdio_buffer);
   startup.lpReserved2 = (BYTE*) process->child_stdio_buffer;
   startup.hStdInput = uv__stdio_handle(process->child_stdio_buffer, 0);


### PR DESCRIPTION
UV_PROCESS_WINDOWS_HIDE enables supression of process windows when launching subprocesses on Windows platforms from a executable linked to the WINDOWS subsystem (as opposed to the CONSOLE subsystem).
