### PR TITLE
windows: support for NULL as uv_work_cb of uv_queue_work callback

### DIFF
--- a/src/win/threadpool.c
+++ b/src/win/threadpool.c
@@ -43,9 +43,9 @@ static DWORD WINAPI uv_work_thread_proc(void* parameter) {
 
   assert(req != NULL);
   assert(req->type == UV_WORK);
-  assert(req->work_cb);
 
-  req->work_cb(req);
+  if(req->work_cb)
+    req->work_cb(req);
 
   POST_COMPLETION_FOR_REQ(loop, req);
 


### PR DESCRIPTION
This will be able to omit uv_work_cb on Windows.
This behavior is same as Unix.

I already signed the CLA.
