### PR TITLE
Use putenv instead of setenv on MinGW

### DIFF
--- a/test/test-spawn.c
+++ b/test/test-spawn.c
@@ -402,7 +402,11 @@ TEST_IMPL(spawn_preserve_env) {
   options.stdio[1].data.stream = (uv_stream_t*) &out;
   options.stdio_count = 2;
 
+#if defined(__MINGW32__)
+  ASSERT(putenv("ENV_TEST=testval") == 0);
+#else
   ASSERT(setenv("ENV_TEST", "testval", 1) == 0);
+#endif
   /* Explicitly set options.env to NULL to test for env clobbering. */
   options.env = NULL;
 


### PR DESCRIPTION
It seems MinGW does not have setenv(). So we must use putenv() instead.
http://octave.1599824.n4.nabble.com/MinGW-build-error-setenv-was-not-declared-in-this-scope-td4644240.html
