### PR TITLE
uv_thread_self() should return uv_thread_t instead of unsigned long

### DIFF
--- a/include/uv.h
+++ b/include/uv.h
@@ -1866,7 +1866,7 @@ UV_EXTERN void uv_once(uv_once_t* guard, void (*callback)(void));
 
 UV_EXTERN int uv_thread_create(uv_thread_t *tid,
     void (*entry)(void *arg), void *arg);
-UV_EXTERN unsigned long uv_thread_self(void);
+UV_EXTERN uv_thread_t uv_thread_self(void);
 UV_EXTERN int uv_thread_join(uv_thread_t *tid);
 
 /* the presence of these unions force similar struct layout */

--- a/src/uv-common.c
+++ b/src/uv-common.c
@@ -316,7 +316,7 @@ int uv_thread_create(uv_thread_t *tid, void (*entry)(void *arg), void *arg) {
 
 uv_thread_t uv_thread_self(void) {
 #ifdef _WIN32
-  return GetCurrentThreadId();
+  return GetCurrentThread();
 #else
   return pthread_self();
 #endif

--- a/src/uv-common.c
+++ b/src/uv-common.c
@@ -314,11 +314,11 @@ int uv_thread_create(uv_thread_t *tid, void (*entry)(void *arg), void *arg) {
 }
 
 
-unsigned long uv_thread_self(void) {
+uv_thread_t uv_thread_self(void) {
 #ifdef _WIN32
-  return (unsigned long) GetCurrentThreadId();
+  return GetCurrentThreadId();
 #else
-  return (unsigned long) pthread_self();
+  return pthread_self();
 #endif
 }
 


### PR DESCRIPTION
Also, GetCurrentThread() should be used instead of GetCurrentThreadId() on Windows.
