### PR TITLE
unix: fix small write immediately followed by uv_read_stop never completes

### DIFF
--- a/src/unix/core.c
+++ b/src/unix/core.c
@@ -661,6 +661,7 @@ void uv__io_stop(uv_loop_t* loop, uv__io_t* w, unsigned int events) {
 
 
 void uv__io_feed(uv_loop_t* loop, uv__io_t* w) {
+  w->pevents |= UV__POLLOUT;
   if (ngx_queue_empty(&w->pending_queue))
     ngx_queue_insert_tail(&loop->pending_queue, &w->pending_queue);
 }


### PR DESCRIPTION
uv__io_feed() would not update the pending events masked to include
UV__POLLOUT, so a subsequent uv__io_stop() call to remove the
UV__POLLIN event would cause the pevents mask to become zero. When
the pevents mask would be zeroed, the io watcher would be removed from
the pending queue.

@bnoordhuis review?
/cc @isaacs This should fix your problem.
