### PR TITLE
kqueue: ignore ENOENT errors when EV_EOF

### DIFF
--- a/src/unix/kqueue.c
+++ b/src/unix/kqueue.c
@@ -197,7 +197,9 @@ void uv__io_poll(uv_loop_t* loop, int timeout) {
           /* TODO batch up */
           struct kevent events[1];
           EV_SET(events + 0, fd, ev->filter, EV_DELETE, 0, 0, 0);
-          if (kevent(loop->backend_fd, events, 1, NULL, 0, NULL)) abort();
+          if (kevent(loop->backend_fd, events, 1, NULL, 0, NULL))
+            if (errno != ENOENT)
+              abort();
         }
       }
 
@@ -208,7 +210,9 @@ void uv__io_poll(uv_loop_t* loop, int timeout) {
           /* TODO batch up */
           struct kevent events[1];
           EV_SET(events + 0, fd, ev->filter, EV_DELETE, 0, 0, 0);
-          if (kevent(loop->backend_fd, events, 1, NULL, 0, NULL)) abort();
+          if (kevent(loop->backend_fd, events, 1, NULL, 0, NULL))
+            if (errno != ENOENT)
+              abort();
         }
       }
 


### PR DESCRIPTION
Some sockets are automatically removed from kqueue upon their
termination, and doing EV_DELETE results in ENOENT. It could be safely
ignored as it isn't a big deal anyway.

This blocks me from using tlsnappy with node 0.9.x, as it `abort()`s suddenly on a benchmark.
