### PR TITLE
unix: fix running loop when all handles are unref'd

### DIFF
--- a/src/unix/core.c
+++ b/src/unix/core.c
@@ -267,8 +267,18 @@ int uv_backend_timeout(const uv_loop_t* loop) {
 }
 
 
+static int uv__loop_alive(uv_loop_t* loop) {
+  return (uv__has_active_handles(loop) || uv__has_active_reqs(loop) ||
+    loop->closing_handles != NULL);
+}
+
+
 int uv_run2(uv_loop_t* loop, uv_run_mode mode) {
   int r;
+
+  if (!uv__loop_alive(loop))
+    return 0;
+
   do {
     uv_update_time(loop);
     uv__run_timers(loop);
@@ -278,7 +288,7 @@ int uv_run2(uv_loop_t* loop, uv_run_mode mode) {
     uv__io_poll(loop, (mode & UV_RUN_NOWAIT ? 0 : uv_backend_timeout(loop)));
     uv__run_check(loop);
     uv__run_closing_handles(loop);
-    r = uv__has_active_handles(loop) || uv__has_active_reqs(loop);
+    r = uv__loop_alive(loop);
   } while (r && !(mode & (UV_RUN_ONCE | UV_RUN_NOWAIT)));
   return r;
 }

--- a/src/unix/loop-watcher.c
+++ b/src/unix/loop-watcher.c
@@ -31,6 +31,8 @@
                                                                               \
   int uv_##name##_start(uv_##name##_t* handle, uv_##name##_cb cb) {           \
     if (uv__is_active(handle)) return 0;                                      \
+    if (cb == NULL)                                                           \
+      return uv__set_artificial_error(handle->loop, UV_EINVAL);               \
     ngx_queue_insert_head(&handle->loop->name##_handles, &handle->queue);     \
     handle->name##_cb = cb;                                                   \
     uv__handle_start(handle);                                                 \
@@ -49,7 +51,7 @@
     ngx_queue_t* q;                                                           \
     ngx_queue_foreach(q, &loop->name##_handles) {                             \
       h = ngx_queue_data(q, uv_##name##_t, queue);                            \
-      if (h->name##_cb) h->name##_cb(h, 0);                                   \
+      h->name##_cb(h, 0);                                                     \
     }                                                                         \
   }                                                                           \
                                                                               \

--- a/src/win/loop-watcher.c
+++ b/src/win/loop-watcher.c
@@ -52,6 +52,9 @@ void uv_loop_watcher_endgame(uv_loop_t* loop, uv_handle_t* handle) {
     if (handle->flags & UV_HANDLE_ACTIVE)                                     \
       return 0;                                                               \
                                                                               \
+    if (cb == NULL)                                                           \
+      return uv__set_artificial_error(handle->loop, UV_EINVAL);               \
+                                                                              \
     old_head = loop->name##_handles;                                          \
                                                                               \
     handle->name##_next = old_head;                                           \

--- a/test/test-ref.c
+++ b/test/test-ref.c
@@ -58,6 +58,11 @@ static void fail_cb(void) {
 }
 
 
+static void fail_cb2() {
+  ASSERT(0 && "fail_cb2 should not have been called");
+}
+
+
 static void req_cb(uv_handle_t* req, int status) {
   req_cb_called++;
 }
@@ -104,7 +109,7 @@ TEST_IMPL(ref) {
 TEST_IMPL(idle_ref) {
   uv_idle_t h;
   uv_idle_init(uv_default_loop(), &h);
-  uv_idle_start(&h, NULL);
+  uv_idle_start(&h, fail_cb2);
   uv_unref((uv_handle_t*)&h);
   uv_run(uv_default_loop());
   do_close(&h);
@@ -127,7 +132,7 @@ TEST_IMPL(async_ref) {
 TEST_IMPL(prepare_ref) {
   uv_prepare_t h;
   uv_prepare_init(uv_default_loop(), &h);
-  uv_prepare_start(&h, NULL);
+  uv_prepare_start(&h, fail_cb2);
   uv_unref((uv_handle_t*)&h);
   uv_run(uv_default_loop());
   do_close(&h);
@@ -139,7 +144,7 @@ TEST_IMPL(prepare_ref) {
 TEST_IMPL(check_ref) {
   uv_check_t h;
   uv_check_init(uv_default_loop(), &h);
-  uv_check_start(&h, NULL);
+  uv_check_start(&h, fail_cb2);
   uv_unref((uv_handle_t*)&h);
   uv_run(uv_default_loop());
   do_close(&h);


### PR DESCRIPTION
Hi!

This pull request contains 2 fixes: the first commit disallows NULL to be passed as a callback to prepare/idle/check handles and modifies the tests accordingly. 

After the first commit, the build fails on unix (test-ref) because the event loop will run once even if all handles are unref'd. This wasn's apparent because the tests in test-ref used NULL as a callback. The second commit fixes this.

/cc @bnoordhuis @piscisaureus
