### PR TITLE
unix: Reset errno when using sendfile emulation

### DIFF
--- a/src/unix/fs.c
+++ b/src/unix/fs.c
@@ -381,6 +381,7 @@ static ssize_t uv__fs_sendfile(uv_fs_t* req) {
         errno == EIO ||
         errno == ENOTSOCK ||
         errno == EXDEV) {
+      errno = 0;
       return uv__fs_sendfile_emul(req);
     }
 
@@ -412,6 +413,7 @@ static ssize_t uv__fs_sendfile(uv_fs_t* req) {
         errno == EIO ||
         errno == ENOTSOCK ||
         errno == EXDEV) {
+      errno = 0;
       return uv__fs_sendfile_emul(req);
     }
 


### PR DESCRIPTION
Here is a case I ran into while testing uv_cancel and fs operations: when a fs request is cancelled req->result will not be set and thus it will have the initial value, that is, 0. So, (please correct me if I'm wrong), the proper way to see if a request failed would be to see if req->errorno is != 0.

Then, when sendfile is used, if it fails but the emulation succeeds req->errorno will be set to ENOTSOCK for example, even if the request succeeded.

/cc @bnoordhuis
