### PR TITLE
unix, win:  add netmask to uv_interface_address

### DIFF
--- a/include/uv.h
+++ b/include/uv.h
@@ -1437,6 +1437,10 @@ struct uv_interface_address_s {
     struct sockaddr_in address4;
     struct sockaddr_in6 address6;
   } address;
+  union {
+    struct sockaddr_in netmask4;
+    struct sockaddr_in6 netmask6;
+  } netmask;
 };
 
 UV_EXTERN char** uv_setup_args(int argc, char** argv);

--- a/src/unix/aix.c
+++ b/src/unix/aix.c
@@ -369,6 +369,8 @@ uv_err_t uv_interface_addresses(uv_interface_address_t** addresses,
       address->address.address4 = *((struct sockaddr_in *)&p->ifr_addr);
     }
 
+    /* TODO: Retrieve netmask using SIOCGIFNETMASK ioctl */
+
     address->is_internal = flg.ifr_flags & IFF_LOOPBACK ? 1 : 0;
 
     address++;

--- a/src/unix/darwin.c
+++ b/src/unix/darwin.c
@@ -435,6 +435,12 @@ uv_err_t uv_interface_addresses(uv_interface_address_t** addresses,
       address->address.address4 = *((struct sockaddr_in *)ent->ifa_addr);
     }
 
+    if (ent->ifa_netmask->sa_family == AF_INET6) {
+      address->netmask.netmask6 = *((struct sockaddr_in6 *)ent->ifa_netmask);
+    } else {
+      address->netmask.netmask4 = *((struct sockaddr_in *)ent->ifa_netmask);
+    }
+
     address->is_internal = ent->ifa_flags & IFF_LOOPBACK ? 1 : 0;
 
     address++;

--- a/src/unix/linux-core.c
+++ b/src/unix/linux-core.c
@@ -770,6 +770,12 @@ uv_err_t uv_interface_addresses(uv_interface_address_t** addresses,
       address->address.address4 = *((struct sockaddr_in *)ent->ifa_addr);
     }
 
+    if (ent->ifa_netmask->sa_family == AF_INET6) {
+      address->netmask.netmask6 = *((struct sockaddr_in6 *)ent->ifa_netmask);
+    } else {
+      address->netmask.netmask4 = *((struct sockaddr_in *)ent->ifa_netmask);
+    }
+
     address->is_internal = ent->ifa_flags & IFF_LOOPBACK ? 1 : 0;
 
     address++;

--- a/src/unix/netbsd.c
+++ b/src/unix/netbsd.c
@@ -331,6 +331,12 @@ uv_err_t uv_interface_addresses(uv_interface_address_t** addresses, int* count) 
       address->address.address4 = *((struct sockaddr_in *)ent->ifa_addr);
     }
 
+    if (ent->ifa_netmask->sa_family == AF_INET6) {
+      address->netmask.netmask6 = *((struct sockaddr_in6 *)ent->ifa_netmask);
+    } else {
+      address->netmask.netmask4 = *((struct sockaddr_in *)ent->ifa_netmask);
+    }
+
     address->is_internal = !!(ent->ifa_flags & IFF_LOOPBACK) ? 1 : 0;
 
     address++;

--- a/src/unix/sunos.c
+++ b/src/unix/sunos.c
@@ -622,6 +622,12 @@ uv_err_t uv_interface_addresses(uv_interface_address_t** addresses,
       address->address.address4 = *((struct sockaddr_in *)ent->ifa_addr);
     }
 
+    if (ent->ifa_netmask->sa_family == AF_INET6) {
+      address->netmask.netmask6 = *((struct sockaddr_in6 *)ent->ifa_netmask);
+    } else {
+      address->netmask.netmask4 = *((struct sockaddr_in *)ent->ifa_netmask);
+    }
+
     address->is_internal = ent->ifa_flags & IFF_PRIVATE || ent->ifa_flags &
 	IFF_LOOPBACK ? 1 : 0;
 

--- a/test/test-platform-output.c
+++ b/test/test-platform-output.c
@@ -80,6 +80,14 @@ TEST_IMPL(platform_output) {
     }
 
     printf("  address: %s\n", buffer);
+
+    if (interfaces[i].netmask.netmask4.sin_family == AF_INET) {
+      uv_ip4_name(&interfaces[i].netmask.netmask4, buffer, sizeof(buffer));
+    } else if (interfaces[i].netmask.netmask4.sin_family == AF_INET6) {
+      uv_ip6_name(&interfaces[i].netmask.netmask6, buffer, sizeof(buffer));
+    }
+
+    printf("  netmask: %s\n", buffer);
   }
   uv_free_interface_addresses(interfaces, count);
 


### PR DESCRIPTION
Include the netmask when returning information about the OS network
interfaces.  The end goal is to get this back to node's `os.networkInterfaces()`
function.

This commit provides implementations for windows and those unix platforms
using getifaddrs().

AIX was not implemented because it requires the use ioctls and I do not
have an AIX development/test environment.  The windows code was developed
using mingw on winxp as I do not have access to visual studio.

Tested on darwin (ipv4/ipv6) and winxp (ipv4 only).  Needs testing on
newer windows using ipv6 and other unix platforms.
