### PR TITLE
windows: pass ENOENT on to process exit callback

### DIFF
--- a/src/win/process.c
+++ b/src/win/process.c
@@ -956,6 +956,7 @@ done:
   /* If an error happened, queue the exit req. */
   if (err.code != UV_OK) {
     process->exit_cb_pending = 1;
+    process->spawn_error = err;
     uv_insert_pending_req(loop, (uv_req_t*) &process->exit_req);
   }
 


### PR DESCRIPTION
This is part of the fix to https://github.com/joyent/node/issues/4674.

The other part is https://github.com/joyent/node/pull/4780.
