### PR TITLE
speed up net write if socket buffer large enough

### DIFF
--- a/include/uv.h
+++ b/include/uv.h
@@ -594,6 +594,15 @@ UV_EXTERN int uv_write(uv_write_t* req, uv_stream_t* handle,
 UV_EXTERN int uv_write2(uv_write_t* req, uv_stream_t* handle, uv_buf_t bufs[],
     int bufcnt, uv_stream_t* send_handle, uv_write_cb cb);
 
+/*
+ * try to write as many data as possible into system buffer for nonblocking io,
+ * if all data is written successfully, async uv wirte can be avoid.
+ * On success, returns the number of bytes sent.
+ * On error, retruns 0 if it needs retry,
+ * otherwise returns -1, and uv__set_sys_error() is called.
+ */
+UV_EXTERN ssize_t uv_try_write(uv_stream_t* handle, const void* buf, size_t count);
+
 /* uv_write_t is a subclass of uv_req_t */
 struct uv_write_s {
   UV_REQ_FIELDS

--- a/src/unix/stream.c
+++ b/src/unix/stream.c
@@ -1261,6 +1261,31 @@ int uv_write(uv_write_t* req, uv_stream_t* stream, uv_buf_t bufs[], int bufcnt,
 }
 
 
+ssize_t uv_try_write(uv_stream_t* stream, const void* buf, size_t count) {
+  ssize_t n;
+  if (stream->type != UV_TCP) {
+    /* only try write for tcp */
+    return 0;
+  }
+
+  if(stream->write_queue_size > 0 || stream->connect_req) {
+    /* do not write if there is data waiting in queue, or the socket is connecting */
+    return 0;
+  }
+
+  n = write(uv__stream_fd(stream), buf, count);
+
+  if (n < 0) {
+    if (errno == EAGAIN || errno == EWOULDBLOCK || errno == EINTR) {
+      return 0;
+    }
+    uv__set_sys_error(stream->loop, errno);
+    return -1;
+  }
+  return n;
+}
+
+
 static int uv__read_start_common(uv_stream_t* stream,
                                  uv_alloc_cb alloc_cb,
                                  uv_read_cb read_cb,


### PR DESCRIPTION
add uv_try_write() to libuv, try to write as many bytes as possible
into socket buffer for nonblocking socket, if all data is written
successfully, async uv write can be avoid, thereby saving the
consumption of uv context and queue operations.

I've opened an issue in node, where explained the reason in detail:
https://github.com/joyent/node/issues/4699

And the corresponding patch for node:
https://github.com/freedaxin/node/commit/d0718d00a231a69c78862bfadab0c7b7b5c59122
