### PR TITLE
Gentle check for send_handle on uv_write2

### DIFF
--- a/src/unix/stream.c
+++ b/src/unix/stream.c
@@ -1193,16 +1193,12 @@ int uv_write2(uv_write_t* req,
       stream->type == UV_TTY) &&
       "uv_write (unix) does not yet support other types of streams");
 
-  if (uv__stream_fd(stream) < 0) {
-    uv__set_sys_error(stream->loop, EBADF);
-    return -1;
-  }
+  if (uv__stream_fd(stream) < 0)
+    return uv__set_sys_error(stream->loop, EBADF);
 
   if (send_handle) {
-    if (stream->type != UV_NAMED_PIPE || !((uv_pipe_t*)stream)->ipc) {
-      uv__set_sys_error(stream->loop, EOPNOTSUPP);
-      return -1;
-    }
+    if (stream->type != UV_NAMED_PIPE || !((uv_pipe_t*)stream)->ipc)
+      return uv__set_sys_error(stream->loop, EOPNOTSUPP);
     if (uv__stream_fd(send_handle) < 0)
       return uv__set_sys_error(stream->loop, EBADF);
   }
@@ -1270,10 +1266,8 @@ static int uv__read_start_common(uv_stream_t* stream,
   assert(stream->type == UV_TCP || stream->type == UV_NAMED_PIPE ||
       stream->type == UV_TTY);
 
-  if (stream->flags & UV_CLOSING) {
-    uv__set_sys_error(stream->loop, EINVAL);
-    return -1;
-  }
+  if (stream->flags & UV_CLOSING)
+    return uv__set_sys_error(stream->loop, EINVAL);
 
   /* The UV_STREAM_READING flag is irrelevant of the state of the tcp - it just
    * expresses the desired state of the user.

--- a/src/unix/stream.c
+++ b/src/unix/stream.c
@@ -1203,6 +1203,8 @@ int uv_write2(uv_write_t* req,
       uv__set_sys_error(stream->loop, EOPNOTSUPP);
       return -1;
     }
+    if (uv__stream_fd(send_handle) < 0)
+      return uv__set_sys_error(stream->loop, EBADF);
   }
 
   empty_queue = (stream->write_queue_size == 0);


### PR DESCRIPTION
As discussed on the mailing list.

I added an extra check, which checks for the send_handle fd and fails early with EBADF. The assert is still there, but I guess the only case when it would blow up is if something really weird happens.

I went for checking the fd in stream and send_handle the same, instead of checking for stream and asserting for send_handle.

Since I was there, I removed a few lines of code by returning directly the value from uv__set_sys_error.
