### PR TITLE
test: add tap output

### DIFF
--- a/test/run-benchmarks.c
+++ b/test/run-benchmarks.c
@@ -60,5 +60,5 @@ static int maybe_run_test(int argc, char **argv) {
     return 42;
   }
 
-  return run_test(argv[1], BENCHMARK_TIMEOUT, 1);
+  return run_test(argv[1], BENCHMARK_TIMEOUT, 1, 1);
 }

--- a/test/run-tests.c
+++ b/test/run-tests.c
@@ -155,5 +155,5 @@ static int maybe_run_test(int argc, char **argv) {
     return 1;
   }
 
-  return run_test(argv[1], TEST_TIMEOUT, 0);
+  return run_test(argv[1], TEST_TIMEOUT, 0, 1);
 }

--- a/test/runner-unix.c
+++ b/test/runner-unix.c
@@ -42,12 +42,15 @@
 /* Do platform-specific initialization. */
 void platform_init(int argc, char **argv) {
   const char* var = getenv("UV_RUN_AS_ROOT");
+  const char* tap = getenv("UV_TAP_OUTPUT");
 
   /* Running the tests as root is not smart - don't do it. */
   if (getuid() == 0 && (var == NULL || atoi(var) <= 0)) {
     fprintf(stderr, "Running the tests as root is not safe.\n");
     exit(1);
   }
+
+  tap_output = (tap != NULL && atoi(tap) > 0);
 
   /* Disable stdio output buffering. */
   setvbuf(stdout, NULL, _IONBF, 0);
@@ -264,16 +267,23 @@ int process_copy_output(process_info_t *p, int fd) {
   ssize_t nread, nwritten;
   char buf[1024];
 
-  while ((nread = read(fileno(p->stdout_file), buf, 1024)) > 0) {
-    nwritten = write(fd, buf, nread);
-    /* TODO: what if write doesn't write the whole buffer... */
+  /* TODO: what if the line is longer than buf */
+  while (fgets(buf, sizeof(buf), p->stdout_file) != NULL) {
+   /* TODO: what if write doesn't write the whole buffer... */
+    nwritten = 0;
+
+    if (tap_output)
+      nwritten += write(fd, "#", 1);
+
+    nwritten += write(fd, buf, strlen(buf));
+
     if (nwritten < 0) {
       perror("write");
       return -1;
     }
   }
 
-  if (nread < 0) {
+  if (ferror(p->stdout_file)) {
     perror("read");
     return -1;
   }

--- a/test/runner.c
+++ b/test/runner.c
@@ -28,6 +28,8 @@
 
 char executable_path[PATHMAX] = { '\0' };
 
+int tap_output = 0;
+
 
 static void log_progress(int total, int passed, int failed, const char* name) {
   if (total == 0)
@@ -76,7 +78,7 @@ const char* fmt(double d) {
 
 
 int run_tests(int timeout, int benchmark_output) {
-  int total, passed, failed;
+  int total, passed, failed, current;
   task_entry_t* task;
 
   /* Count the number of tests. */
@@ -87,29 +89,35 @@ int run_tests(int timeout, int benchmark_output) {
     }
   }
 
+  if (tap_output) {
+    LOGF("1..%d\n", total);
+  }
+
   /* Run all tests. */
   passed = 0;
   failed = 0;
+  current = 1;
   for (task = TASKS; task->main; task++) {
     if (task->is_helper) {
       continue;
     }
 
     rewind_cursor();
-    if (!benchmark_output) {
+    if (!benchmark_output && !tap_output) {
       log_progress(total, passed, failed, task->task_name);
     }
 
-    if (run_test(task->task_name, timeout, benchmark_output) == 0) {
+    if (run_test(task->task_name, timeout, benchmark_output, current) == 0) {
       passed++;
     } else {
       failed++;
     }
+    current++;
   }
 
   rewind_cursor();
 
-  if (!benchmark_output) {
+  if (!benchmark_output && !tap_output) {
     log_progress(total, passed, failed, "Done.\n");
   }
 
@@ -117,7 +125,8 @@ int run_tests(int timeout, int benchmark_output) {
 }
 
 
-int run_test(const char* test, int timeout, int benchmark_output) {
+int run_test(const char* test, int timeout, int benchmark_output,
+             int test_count) {
   char errmsg[1024] = "no error";
   process_info_t processes[1024];
   process_info_t *main_proc;
@@ -243,7 +252,9 @@ out:
 
   /* Show error and output from processes if the test failed. */
   if (status != 0 || task->show_output) {
-    if (status != 0) {
+    if (tap_output) {
+      LOGF("not ok %d - %s\n#", test_count, test);
+    } else if (status != 0) {
       LOGF("\n`%s` failed: %s\n", test, errmsg);
     } else {
       LOGF("\n");
@@ -267,7 +278,10 @@ out:
         break;
       }
     }
-    LOG("=============================================================\n");
+
+    if (!tap_output) {
+      LOG("=============================================================\n");
+    }
 
   /* In benchmark mode show concise output from the main process. */
   } else if (benchmark_output) {
@@ -286,6 +300,8 @@ out:
       }
       break;
     }
+  } else if (tap_output) {
+    LOGF("ok %d - %s\n", test_count, test);
   }
 
   /* Clean up all process handles. */

--- a/test/runner.h
+++ b/test/runner.h
@@ -102,7 +102,7 @@ int run_tests(int timeout, int benchmark_output);
 /*
  * Run a single test. Starts up any helpers.
  */
-int run_test(const char* test, int timeout, int benchmark_output);
+int run_test(const char* test, int timeout, int benchmark_output, int test_count);
 
 /*
  * Run a test part, i.e. the test or one of its helpers.
@@ -155,5 +155,8 @@ void process_cleanup(process_info_t *p);
 
 /* Move the console cursor one line up and back to the first column. */
 void rewind_cursor(void);
+
+/* trigger output as tap */
+extern int tap_output;
 
 #endif /* RUNNER_H_ */


### PR DESCRIPTION
Given UV_TAP_OUTPUT being set, test result output should use TAP formatting

TODO: Windows implementation
