### PR TITLE
Added -fPIC to CFLAGS

### DIFF
--- a/config-unix.mk
+++ b/config-unix.mk
@@ -20,7 +20,7 @@
 
 E=
 CSTDFLAG=--std=c89 -pedantic -Wall -Wextra -Wno-unused-parameter
-CFLAGS += -g
+CFLAGS += -g -fPIC
 CPPFLAGS += -I$(SRCDIR)/src
 LDFLAGS=-lm
 


### PR DESCRIPTION
Without this, make fails on x64 machines.

Maybe there's a better place to put it, though ?
