### PR TITLE
Include extra libs to support Reg calls and CommandLineToArgW

### DIFF
--- a/uv.gyp
+++ b/uv.gyp
@@ -102,7 +102,9 @@
             'libraries': [
               '-lws2_32.lib',
               '-lpsapi.lib',
-              '-liphlpapi.lib'
+              '-liphlpapi.lib',
+              '-ladvapi32.lib',
+              '-lShell32.lib'
             ],
           },
         }, { # Not Windows i.e. POSIX


### PR DESCRIPTION
Without those 2 libs, compiling on Win7, VS2010 was failing with:

test-spawn.obj : error LNK2001: unresolved external symbol __imp__CommandLineToArgvW@8 [C:\libuv\run-tests.vcxproj]
libuv.lib(util.obj) : error LNK2001: unresolved external symbol __imp__RegQueryValueExW@24 [C:\libuv\run-tests.vcxproj]
libuv.lib(util.obj) : error LNK2001: unresolved external symbol __imp__RegOpenKeyExW@20 [C:\libuv\run-tests.vcxproj]
libuv.lib(util.obj) : error LNK2001: unresolved external symbol __imp__RegCloseKey@4 [C:\libuv\run-tests.vcxproj]
C:\libuv\Release\run-tests.exe : fatal error LNK1120: 4 unresolved externals
[C:\libuv\run-tests.vcxproj]
