### PR TITLE
Add interval and count to keep-alive

### DIFF
--- a/include/uv.h
+++ b/include/uv.h
@@ -653,11 +653,16 @@ UV_EXTERN int uv_tcp_nodelay(uv_tcp_t* handle, int enable);
 /*
  * Enable/disable TCP keep-alive.
  *
- * `delay` is the initial delay in seconds, ignored when `enable` is zero.
+ * Options below are ignored when `enable` is zero.
+ * `delay` is the initial delay in seconds. If 0, value is ignored.
+ * `interval` is the interval in seconds after initial probe. If 0, value is ignored.
+ * `count` is the number of failed probes before flagging socket dead. If 0, value is ignored. Unix-only.
  */
 UV_EXTERN int uv_tcp_keepalive(uv_tcp_t* handle,
                                int enable,
-                               unsigned int delay);
+                               unsigned int delay,
+                               unsigned int interval,
+                               unsigned int count);
 
 /*
  * This setting applies to Windows only.

--- a/src/unix/internal.h
+++ b/src/unix/internal.h
@@ -152,7 +152,7 @@ int uv__accept(int sockfd);
 /* tcp */
 int uv_tcp_listen(uv_tcp_t* tcp, int backlog, uv_connection_cb cb);
 int uv__tcp_nodelay(int fd, int on);
-int uv__tcp_keepalive(int fd, int on, unsigned int delay);
+int uv__tcp_keepalive(int fd, int on, unsigned int delay, unsigned int interval, unsigned int count);
 
 /* pipe */
 int uv_pipe_listen(uv_pipe_t* handle, int backlog, uv_connection_cb cb);

--- a/src/unix/stream.c
+++ b/src/unix/stream.c
@@ -363,8 +363,8 @@ int uv__stream_open(uv_stream_t* stream, int fd, int flags) {
     if ((stream->flags & UV_TCP_NODELAY) && uv__tcp_nodelay(fd, 1))
       return uv__set_sys_error(stream->loop, errno);
 
-    /* TODO Use delay the user passed in. */
-    if ((stream->flags & UV_TCP_KEEPALIVE) && uv__tcp_keepalive(fd, 1, 60))
+    /* TODO Use delay, interval, count the user passed in. */
+    if ((stream->flags & UV_TCP_KEEPALIVE) && uv__tcp_keepalive(fd, 1, 60, 0, 0))
       return uv__set_sys_error(stream->loop, errno);
   }
 

--- a/test/test-tcp-flags.c
+++ b/test/test-tcp-flags.c
@@ -39,7 +39,7 @@ TEST_IMPL(tcp_flags) {
   r = uv_tcp_nodelay(&handle, 1);
   ASSERT(r == 0);
 
-  r = uv_tcp_keepalive(&handle, 1, 60);
+  r = uv_tcp_keepalive(&handle, 1, 60, 60, 8);
   ASSERT(r == 0);
 
   uv_close((uv_handle_t*)&handle, NULL);


### PR DESCRIPTION
The default probe interval and failure counts set by the OS are way too extreme and if you have a real-time socket server, you're going to want to customize these so you can have a much lower keep-alive interval and count so you're notified of disconnected sockets sooner.

Unfortunately, Windows doesn't let you set count, but using SIO_KEEPALIVE_VALS we can set interval (see: http://msdn.microsoft.com/en-us/library/windows/desktop/dd877220(v=vs.85).aspx). The defaults for the OS are 2 hour timeouts and 1 second intervals. I was hesitant about setting the default 1 second because that's pretty insane but decided just to leave it.
