### PR TITLE
win: Map ERROR_INVALID_FUNCTION to EISDIR

### DIFF
--- a/src/win/error.c
+++ b/src/win/error.c
@@ -157,6 +157,7 @@ uv_err_code uv_translate_sys_error(int sys_errno) {
     case ERROR_SEM_TIMEOUT:                 return UV_ETIMEDOUT;
     case WSAETIMEDOUT:                      return UV_ETIMEDOUT;
     case ERROR_NOT_SAME_DEVICE:             return UV_EXDEV;
+    case ERROR_INVALID_FUNCTION:            return UV_EISDIR;
     default:                                return UV_UNKNOWN;
   }
 }


### PR DESCRIPTION
This error is raised when calling read() or write() on a directory.

A bit of googling turns up some cases where this error can be raised
that are not properly mapped to EISDIR, but are also cases that libuv
doesn't really care about, like the Password Manager API,
GetFirmwareEnvironmentVariable, or CreateTapePartition.

If libuv ever needs to handle these cases, then I suppose that the
ERROR_INVALID_FUNCTION->EISDIR mapping could be done directly in the
fs read() and write() functions, but doing so at this point seems
premature, as it makes the error code mapping a bit more messy.

Fixes joyent/node#4951

cc: @sblom @piscisaureus
