### PR TITLE
WIP: uv_fs_[fl]stat should support subsecond resolution

### DIFF
--- a/include/uv-private/uv-unix.h
+++ b/include/uv-private/uv-unix.h
@@ -121,7 +121,6 @@ typedef struct {
 
 typedef int uv_file;
 typedef int uv_os_sock_t;
-typedef struct stat uv_statbuf_t;
 
 #define UV_ONCE_INIT PTHREAD_ONCE_INIT
 

--- a/include/uv-private/uv-win.h
+++ b/include/uv-private/uv-win.h
@@ -207,8 +207,6 @@ typedef struct uv_buf_t {
 
 typedef int uv_file;
 
-typedef struct _stati64 uv_statbuf_t;
-
 typedef SOCKET uv_os_sock_t;
 
 typedef HANDLE uv_thread_t;

--- a/include/uv.h
+++ b/include/uv.h
@@ -350,6 +350,29 @@ typedef void (*uv_getaddrinfo_cb)(uv_getaddrinfo_t* req,
                                   int status,
                                   struct addrinfo* res);
 
+typedef struct {
+  long tv_sec;
+  long tv_nsec;
+} uv_timespec_t;
+
+
+typedef struct {
+  uint64_t st_dev;
+  uint64_t st_mode;
+  uint64_t st_nlink;
+  uint64_t st_uid;
+  uint64_t st_gid;
+  uint64_t st_rdev;
+  uint64_t st_ino;
+  uint64_t st_size;
+  uint64_t st_blksize;
+  uint64_t st_blocks;
+  uv_timespec_t st_atim;
+  uv_timespec_t st_mtim;
+  uv_timespec_t st_ctim;
+} uv_stat_t;
+
+
 /*
 * This will be called repeatedly after the uv_fs_event_t is initialized.
 * If uv_fs_event_t was initialized with a directory the filename parameter
@@ -361,8 +384,8 @@ typedef void (*uv_fs_event_cb)(uv_fs_event_t* handle, const char* filename,
 
 typedef void (*uv_fs_poll_cb)(uv_fs_poll_t* handle,
                               int status,
-                              const uv_statbuf_t* prev,
-                              const uv_statbuf_t* curr);
+                              const uv_stat_t* prev,
+                              const uv_stat_t* curr);
 
 typedef void (*uv_signal_cb)(uv_signal_t* handle, int signum);
 
@@ -1519,7 +1542,7 @@ struct uv_fs_s {
   void* ptr;
   const char* path;
   uv_err_code errorno;
-  uv_statbuf_t statbuf;  /* Stores the result of uv_fs_stat and uv_fs_fstat. */
+  uv_stat_t statbuf;  /* Stores the result of uv_fs_stat and uv_fs_fstat. */
   UV_FS_PRIVATE_FIELDS
 };
 
@@ -1646,7 +1669,7 @@ UV_EXTERN int uv_fs_poll_init(uv_loop_t* loop, uv_fs_poll_t* handle);
  * or the error reason changes).
  *
  * When `status == 0`, your callback receives pointers to the old and new
- * `uv_statbuf_t` structs. They are valid for the duration of the callback
+ * `uv_stat_t` structs. They are valid for the duration of the callback
  * only!
  *
  * For maximum portability, use multi-second intervals. Sub-second intervals

--- a/src/fs-poll.c
+++ b/src/fs-poll.c
@@ -35,16 +35,16 @@ struct poll_ctx {
   uv_fs_poll_cb poll_cb;
   uv_timer_t timer_handle;
   uv_fs_t fs_req; /* TODO(bnoordhuis) mark fs_req internal */
-  uv_statbuf_t statbuf;
+  uv_stat_t statbuf;
   char path[1]; /* variable length */
 };
 
-static int statbuf_eq(const uv_statbuf_t* a, const uv_statbuf_t* b);
+static int statbuf_eq(const uv_stat_t* a, const uv_stat_t* b);
 static void poll_cb(uv_fs_t* req);
 static void timer_cb(uv_timer_t* timer, int status);
 static void timer_close_cb(uv_handle_t* handle);
 
-static uv_statbuf_t zero_statbuf;
+static uv_stat_t zero_statbuf;
 
 
 int uv_fs_poll_init(uv_loop_t* loop, uv_fs_poll_t* handle) {
@@ -137,7 +137,7 @@ static void timer_cb(uv_timer_t* timer, int status) {
 
 
 static void poll_cb(uv_fs_t* req) {
-  uv_statbuf_t* statbuf;
+  uv_stat_t* statbuf;
   struct poll_ctx* ctx;
   uint64_t interval;
 
@@ -189,48 +189,17 @@ static void timer_close_cb(uv_handle_t* handle) {
 }
 
 
-static int statbuf_eq(const uv_statbuf_t* a, const uv_statbuf_t* b) {
-#if defined(_WIN32)
-  return a->st_mtime == b->st_mtime
-      && a->st_size == b->st_size
-      && a->st_mode == b->st_mode;
-#else
-
-  /* Jump through a few hoops to get sub-second granularity on Linux. */
-# if defined(__linux__)
-#  if defined(__USE_MISC) /* _BSD_SOURCE || _SVID_SOURCE */
-  if (a->st_ctim.tv_nsec != b->st_ctim.tv_nsec) return 0;
-  if (a->st_mtim.tv_nsec != b->st_mtim.tv_nsec) return 0;
-#  else
-  if (a->st_ctimensec != b->st_ctimensec) return 0;
-  if (a->st_mtimensec != b->st_mtimensec) return 0;
-#  endif
-# endif
-
-  /* Jump through different hoops on OS X. */
-# if defined(__APPLE__)
-#  if !defined(_POSIX_C_SOURCE) || defined(_DARWIN_C_SOURCE)
-  if (a->st_ctimespec.tv_nsec != b->st_ctimespec.tv_nsec) return 0;
-  if (a->st_mtimespec.tv_nsec != b->st_mtimespec.tv_nsec) return 0;
-#  else
-  if (a->st_ctimensec != b->st_ctimensec) return 0;
-  if (a->st_mtimensec != b->st_mtimensec) return 0;
-#  endif
-# endif
-
-  /* TODO(bnoordhuis) Other Unices have st_ctim and friends too, provided
-   * the stars and compiler flags are right...
-   */
-
-  return a->st_ctime == b->st_ctime
-      && a->st_mtime == b->st_mtime
+static int statbuf_eq(const uv_stat_t* a, const uv_stat_t* b) {
+  return a->st_ctim.tv_nsec == b->st_ctim.tv_nsec
+      && a->st_mtim.tv_nsec == b->st_mtim.tv_nsec
+      && a->st_ctim.tv_sec == b->st_ctim.tv_sec
+      && a->st_mtim.tv_sec == b->st_mtim.tv_sec
       && a->st_size == b->st_size
       && a->st_mode == b->st_mode
       && a->st_uid == b->st_uid
       && a->st_gid == b->st_gid
       && a->st_ino == b->st_ino
       && a->st_dev == b->st_dev;
-#endif
 }
 
 

--- a/test/test-fs-poll.c
+++ b/test/test-fs-poll.c
@@ -30,8 +30,8 @@ static void timer_cb(uv_timer_t* handle, int status);
 static void close_cb(uv_handle_t* handle);
 static void poll_cb(uv_fs_poll_t* handle,
                     int status,
-                    const uv_statbuf_t* prev,
-                    const uv_statbuf_t* curr);
+                    const uv_stat_t* prev,
+                    const uv_stat_t* curr);
 
 static uv_fs_poll_t poll_handle;
 static uv_timer_t timer_handle;
@@ -74,9 +74,9 @@ static void timer_cb(uv_timer_t* handle, int status) {
 
 static void poll_cb(uv_fs_poll_t* handle,
                     int status,
-                    const uv_statbuf_t* prev,
-                    const uv_statbuf_t* curr) {
-  uv_statbuf_t zero_statbuf;
+                    const uv_stat_t* prev,
+                    const uv_stat_t* curr) {
+  uv_stat_t zero_statbuf;
 
   memset(&zero_statbuf, 0, sizeof(zero_statbuf));
 


### PR DESCRIPTION
This adds uv_stat_t with a consistent interface across platforms, and on platforms where it's supported ->st_mtim.tv_nsec will be populated

currently only for unix, and doesn't check if we're on a platform where it's not supported.
