### PR TITLE
UNC paths on search_path for uv_spawn

### DIFF
--- a/src/win/process.c
+++ b/src/win/process.c
@@ -111,8 +111,10 @@ static WCHAR* search_path_join_test(const WCHAR* dir,
                                     size_t cwd_len) {
   WCHAR *result, *result_pos;
   DWORD attrs;
-
-  if (dir_len >= 1 && (dir[0] == L'/' || dir[0] == L'\\')) {
+  if (dir_len > 2 && dir[0] == L'\\' && dir[1] == L'\\') {
+	/* It's a UNC path so ignore cwd */
+	cwd_len = 0;
+  } else if (dir_len >= 1 && (dir[0] == L'/' || dir[0] == L'\\')) {
     /* It's a full path without drive letter, use cwd's drive letter only */
     cwd_len = 2;
   } else if (dir_len >= 2 && dir[1] == L':' &&
@@ -271,7 +273,6 @@ static WCHAR* path_search_walk_ext(const WCHAR *dir,
  *   file that is not readable/executable; if the spawn fails it will not
  *   continue searching.
  *
- * TODO: correctly interpret UNC paths
  */
 static WCHAR* search_path(const WCHAR *file,
                             WCHAR *cwd,


### PR DESCRIPTION
Support UNC paths on the PATH env when searching for an executable to spawn a process
