### PR TITLE
unix, windows: don't read/recv if buf.len==0

### DIFF
--- a/include/uv.h
+++ b/include/uv.h
@@ -342,6 +342,12 @@ UV_EXTERN int uv_backend_timeout(const uv_loop_t*);
  *
  * `suggested_size` is a hint. Returning a buffer that is smaller is perfectly
  * okay as long as `buf.len > 0`.
+ *
+ * If you return a buffer with `buf.len == 0`, libuv skips the read and calls
+ * your read or recv callback with nread=UV_ENOBUFS.
+ *
+ * Note that returning a zero-length buffer does not stop the handle, call
+ * uv_read_stop() or uv_udp_recv_stop() for that.
  */
 typedef uv_buf_t (*uv_alloc_cb)(uv_handle_t* handle, size_t suggested_size);
 

--- a/src/unix/udp.c
+++ b/src/unix/udp.c
@@ -205,8 +205,11 @@ static void uv__udp_recvmsg(uv_loop_t* loop,
   h.msg_name = &peer;
 
   do {
-    buf = handle->alloc_cb((uv_handle_t*)handle, 64 * 1024);
-    assert(buf.len > 0);
+    buf = handle->alloc_cb((uv_handle_t*) handle, 64 * 1024);
+    if (buf.len == 0) {
+      handle->recv_cb(handle, UV_ENOBUFS, buf, NULL, 0);
+      return;
+    }
     assert(buf.base != NULL);
 
     h.msg_namelen = sizeof(peer);

--- a/src/win/pipe.c
+++ b/src/win/pipe.c
@@ -1429,7 +1429,15 @@ void uv_process_pipe_read_req(uv_loop_t* loop, uv_pipe_t* handle,
       }
 
       buf = handle->alloc_cb((uv_handle_t*) handle, avail);
-      assert(buf.len > 0);
+      if (buf.len == 0) {
+        if (handle->read2_cb) {
+          handle->read2_cb(handle, UV_ENOBUFS, buf, UV_UNKNOWN_HANDLE);
+        } else if (handle->read_cb) {
+          handle->read_cb((uv_stream_t*) handle, UV_ENOBUFS, buf);
+        }
+        break;
+      }
+      assert(buf.base != NULL);
 
       if (ReadFile(handle->handle,
                    buf.base,

--- a/src/win/udp.c
+++ b/src/win/udp.c
@@ -272,7 +272,11 @@ static void uv_udp_queue_recv(uv_loop_t* loop, uv_udp_t* handle) {
     handle->flags &= ~UV_HANDLE_ZERO_READ;
 
     handle->recv_buffer = handle->alloc_cb((uv_handle_t*) handle, 65536);
-    assert(handle->recv_buffer.len > 0);
+    if (handle->recv_buffer.len == 0) {
+      handle->recv_cb(handle, UV_ENOBUFS, handle->recv_buffer, NULL, 0);
+      return;
+    }
+    assert(handle->recv_buffer.base != NULL);
 
     buf = handle->recv_buffer;
     memset(&handle->recv_from, 0, sizeof handle->recv_from);
@@ -515,7 +519,11 @@ void uv_process_udp_recv_req(uv_loop_t* loop, uv_udp_t* handle,
     /* Do a nonblocking receive */
     /* TODO: try to read multiple datagrams at once. FIONREAD maybe? */
     buf = handle->alloc_cb((uv_handle_t*) handle, 65536);
-    assert(buf.len > 0);
+    if (buf.len == 0) {
+      handle->recv_cb(handle, UV_ENOBUFS, buf, NULL, 0);
+      goto done;
+    }
+    assert(buf.base != NULL);
 
     memset(&from, 0, sizeof from);
     from_len = sizeof from;


### PR DESCRIPTION
Make it possible for the libuv user to handle out of memory conditions
gracefully. When alloc_cb() returns a buffer with len==0, call the read
or recv callback with nread=-1 and error=UV_ENOBUFS. It's up to the
user to close the handle.

Fixes #752.

Suggested reviewer: @piscisaureus

I tried to exercise due diligence when going over the Windows code but it's completely untested. View it as a starting point for you to improve on. :-)
