### PR TITLE
doc,unix: uv_udp_open supports all datagrams

### DIFF
--- a/include/uv.h
+++ b/include/uv.h
@@ -787,6 +787,12 @@ UV_EXTERN int uv_udp_init(uv_loop_t*, uv_udp_t* handle);
 
 /*
  * Opens an existing file descriptor or SOCKET as a udp handle.
+ *
+ * Unix only:  
+ *  The only requirement of the sock argument is that it follows the
+ *  datagram contract (works in unconnected mode, supports sendmsg()/recvmsg(),
+ *  etc.). In other words, other datagram-type sockets like raw sockets or
+ *  netlink sockets can also be passed to this function.
  */
 UV_EXTERN int uv_udp_open(uv_udp_t* handle, uv_os_sock_t sock);
 


### PR DESCRIPTION
On Unix, uv_udp_open can be used with any socket as long as the socket follows the datagram contract. This means that any datagram-socket, like for example netlink or raw sockets, can be used with libuv. I think this is very useful and expands the possible use cases for libuv, and should be documented.
