### PR TITLE
doc: add reference to Visual Studio Express in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,10 +109,14 @@ autotools, add a `AC_GNU_SOURCE` declaration to your `configure.ac`.
 ## Supported Platforms
 
 Microsoft Windows operating systems since Windows XP SP2. It can be built
-with either Visual Studio or MinGW.
+with either Visual Studio or MinGW. Consider using
+[Visual Studio Express 2010][] or later if you do not have a full Visual
+Studio license.
 
 Linux 2.6 using the GCC toolchain.
 
 MacOS using the GCC or XCode toolchain.
 
 Solaris 121 and later using GCC toolchain.
+
+[Visual Studio Express 2010]: http://www.microsoft.com/visualstudio/eng/products/visual-studio-2010-express


### PR DESCRIPTION
Until recently I was under the impression MinGW was the only option for building on windows if you did not own a Visual Studio license.  @isaacs set me straight and told me about VS Express.

Since others coming from a unix background may not be aware of this either, consider adding a reference to Visual Studio Express in the README.
