### PR TITLE
build: Update build.mk

### DIFF
--- a/build.mk
+++ b/build.mk
@@ -160,5 +160,5 @@ bench: run-benchmarks$(E)
 clean distclean: clean-platform
 	$(RM) libuv.a libuv.$(SOEXT) \
 		test/run-tests.o test/run-benchmarks.o \
-		test/run-tests$(E) test/run-benchmarks$(E) \
+		test/runner.o run-tests$(E) test/run-benchmarks$(E) \
 		$(BENCHMARKS) $(TESTS) $(RUNNER_LIBS)


### PR DESCRIPTION
Clean `make test` build objects properly.  I ran into this when packaging `libuv` on debian, as when packaging it is important to be able to clean and return to a pristine state.
