### PR TITLE
unix: dtrace probes for tick-start and tick-stop

### DIFF
--- a/common.gypi
+++ b/common.gypi
@@ -132,6 +132,11 @@
       [ 'OS=="linux" or OS=="freebsd" or OS=="openbsd" or OS=="solaris"', {
         'cflags': [ '-Wall' ],
         'cflags_cc': [ '-fno-rtti', '-fno-exceptions' ],
+        'target_conditions': [
+          ['_type=="static_library"', {
+            'standalone_static_library': 1, # disable thin archive which needs binutils >= 2.19
+          }],
+        ],
         'conditions': [
           [ 'host_arch != target_arch and target_arch=="ia32"', {
             'cflags': [ '-m32' ],

--- a/common.gypi
+++ b/common.gypi
@@ -197,6 +197,11 @@
           }],
         ],
       }],
+     ['OS=="solaris"', {
+       'cflags': [ '-fno-omit-frame-pointer' ],
+       # pull in V8's postmortem metadata
+       'ldflags': [ '-Wl,-z,allextract' ]
+     }],
     ],
   },
 }

--- a/config-unix.mk
+++ b/config-unix.mk
@@ -33,6 +33,10 @@ RUNNER_SRC=test/runner-unix.c
 RUNNER_CFLAGS=$(CFLAGS) -I$(SRCDIR)/test
 RUNNER_LDFLAGS=-L"$(CURDIR)" -luv -Xlinker -rpath -Xlinker "$(CURDIR)"
 
+HAVE_DTRACE=
+DTRACE_OBJS=
+DTRACE_HEADER=
+
 OBJS += src/unix/async.o
 OBJS += src/unix/core.o
 OBJS += src/unix/dl.o
@@ -58,11 +62,14 @@ OBJS += src/inet.o
 OBJS += src/version.o
 
 ifeq (sunos,$(PLATFORM))
+HAVE_DTRACE=1
 CPPFLAGS += -D__EXTENSIONS__ -D_XOPEN_SOURCE=500
 LDFLAGS+=-lkstat -lnsl -lsendfile -lsocket
 # Library dependencies are not transitive.
 RUNNER_LDFLAGS += $(LDFLAGS)
 OBJS += src/unix/sunos.o
+OBJS += src/unix/dtrace.o
+DTRACE_OBJS += src/unix/core.o
 endif
 
 ifeq (aix,$(PLATFORM))
@@ -72,6 +79,7 @@ OBJS += src/unix/aix.o
 endif
 
 ifeq (darwin,$(PLATFORM))
+HAVE_DTRACE=1
 CPPFLAGS += -D_DARWIN_USE_64_BIT_INODE=1
 LDFLAGS += -framework Foundation \
            -framework CoreServices \
@@ -96,6 +104,7 @@ OBJS += src/unix/linux-core.o \
 endif
 
 ifeq (freebsd,$(PLATFORM))
+HAVE_DTRACE=1
 LDFLAGS+=-lkvm
 OBJS += src/unix/freebsd.o
 OBJS += src/unix/kqueue.o
@@ -132,6 +141,11 @@ else
 RUNNER_LDFLAGS += -pthread
 endif
 
+ifeq ($(HAVE_DTRACE), 1)
+DTRACE_HEADER=src/unix/uv-dtrace.h
+CFLAGS += -DHAVE_DTRACE
+endif
+
 libuv.a: $(OBJS)
 	$(AR) rcs $@ $^
 
@@ -152,7 +166,7 @@ src/.buildstamp src/unix/.buildstamp test/.buildstamp:
 	mkdir -p $(@D)
 	touch $@
 
-src/unix/%.o src/unix/%.pic.o: src/unix/%.c include/uv.h include/uv-private/uv-unix.h src/unix/internal.h src/unix/.buildstamp
+src/unix/%.o src/unix/%.pic.o: src/unix/%.c include/uv.h include/uv-private/uv-unix.h src/unix/internal.h src/unix/.buildstamp $(DTRACE_HEADER)
 	$(CC) $(CSTDFLAG) $(CPPFLAGS) $(CFLAGS) -c $< -o $@
 
 src/%.o src/%.pic.o: src/%.c include/uv.h include/uv-private/uv-unix.h src/.buildstamp
@@ -162,7 +176,16 @@ test/%.o: test/%.c include/uv.h test/.buildstamp
 	$(CC) $(CSTDFLAG) $(CPPFLAGS) $(CFLAGS) -c $< -o $@
 
 clean-platform:
-	$(RM) test/run-{tests,benchmarks}.dSYM $(OBJS) $(OBJS:%.o=%.pic.o)
+	$(RM) test/run-{tests,benchmarks}.dSYM $(OBJS) $(OBJS:%.o=%.pic.o) src/unix/uv-dtrace.h
 
 %.pic.o %.o:  %.m
 	$(OBJC) $(CPPFLAGS) $(CFLAGS) -c $^ -o $@
+
+src/unix/uv-dtrace.h: src/unix/uv-dtrace.d
+	dtrace -h -xnolibs -s src/unix/uv-dtrace.d -o $@
+
+src/unix/dtrace.o: src/unix/uv-dtrace.d $(DTRACE_OBJS)
+	dtrace -G -s $^ -o $@
+
+src/unix/dtrace.pic.o: src/unix/uv-dtrace.d $(DTRACE_OBJS:%.o=%.pic.o)
+	dtrace -G -s $^ -o $@

--- a/src/unix/core.c
+++ b/src/unix/core.c
@@ -299,6 +299,8 @@ int uv_run(uv_loop_t* loop, uv_run_mode mode) {
 
   r = uv__loop_alive(loop);
   while (r != 0 && loop->stop_flag == 0) {
+    UV_TICK_START(loop, mode);
+
     uv__update_time(loop);
     uv__run_timers(loop);
     uv__run_idle(loop);
@@ -313,6 +315,8 @@ int uv_run(uv_loop_t* loop, uv_run_mode mode) {
     uv__run_check(loop);
     uv__run_closing_handles(loop);
     r = uv__loop_alive(loop);
+
+    UV_TICK_STOP(loop, mode);
 
     if (mode & (UV_RUN_ONCE | UV_RUN_NOWAIT))
       break;

--- a/src/unix/internal.h
+++ b/src/unix/internal.h
@@ -256,4 +256,11 @@ static void uv__update_time(uv_loop_t* loop) {
   loop->time = uv__hrtime() / 1000000;
 }
 
+#ifdef HAVE_DTRACE
+#include "uv-dtrace.h"
+#else
+#define UV_TICK_START(arg0, arg1)
+#define UV_TICK_STOP(arg0, arg1)
+#endif
+
 #endif /* UV_UNIX_INTERNAL_H_ */

--- a/src/unix/uv-dtrace.d
+++ b/src/unix/uv-dtrace.d
@@ -1,0 +1,25 @@
+/* Copyright Joyent, Inc. and other Node contributors. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to
+ * deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+
+provider uv {
+  probe tick__start(void* loop, int mode);
+  probe tick__stop(void* loop, int mode);
+};


### PR DESCRIPTION
Adds probes for start of tick and end of tick.

The Makefile change isn't as pretty as I would have liked.

Disabling thin archives was required to do a gyp build on smartos, adding allextract was necessary in for gyp builds to make sure run-tests and run-benchmarks actually got the dtrace symbols.
