### PR TITLE
mingw-w64: fix _set_invalid_parameter_handler

### DIFF
--- a/src/win/core.c
+++ b/src/win/core.c
@@ -55,9 +55,11 @@ static void uv_init(void) {
 
   /* Tell the CRT to not exit the application when an invalid parameter is */
   /* passed. The main issue is that invalid FDs will trigger this behavior. */
+#if !defined(__MINGW32__) || __MSVCRT_VERSION__ >= 0x800
 #ifdef _WRITE_ABORT_MSG
   _set_invalid_parameter_handler(uv__crt_invalid_parameter_handler);
-#endif
+#endif // _WRITE_ABORT_MSG
+#endif // !defined(__MINGW32__) || __MSVCRT_VERSION__ >= 0x800
 
   /* Fetch winapi function pointers. This must be done first because other */
   /* intialization code might need these function pointers to be loaded. */


### PR DESCRIPTION
Check the **MSVCRT_VERSION**, as mingw-w64 does always define
_WRITE_ABORT_MSG.
