### PR TITLE
darwin: fix unnecessary include headers

### DIFF
--- a/src/unix/darwin-proctitle.m
+++ b/src/unix/darwin-proctitle.m
@@ -18,7 +18,7 @@
  * IN THE SOFTWARE.
  */
 
-#include <Cocoa/Cocoa.h>
+#include <CoreFoundation/CoreFoundation.h>
 
 
 int uv__set_process_title(const char* title) {


### PR DESCRIPTION
This file doesn't use any Cocoa functions, CoreFoundation.h is enough here.
This line causes compilation error on iOS environment.

And also, this file is compiled as Objective-C file but I think this is not necessary too.
This file doesn't use any Objective-C feature, and can be compiled as plain C file.
(This pull request doesn't care of this though)
