### PR TITLE
build: If user already has $PLATFORM defined, convert to lower case

### DIFF
--- a/build.mk
+++ b/build.mk
@@ -18,7 +18,11 @@
 # FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 # IN THE SOFTWARE.
 
-PLATFORM ?= $(shell sh -c 'uname -s | tr "[A-Z]" "[a-z]"')
+ifdef PLATFORM
+override PLATFORM := $(shell echo $(PLATFORM) | tr "[A-Z]" "[a-z]")
+else
+PLATFORM = $(shell sh -c 'uname -s | tr "[A-Z]" "[a-z]"')
+endif
 
 CPPFLAGS += -I$(SRCDIR)/include -I$(SRCDIR)/include/uv-private
 


### PR DESCRIPTION
Useful for when users already have `$PLATFORM` set to `uname -s`, but on e.g. OSX `uname -s` is equal to "Darwin", therefore the build is missing some symbols.
