### PR TITLE
unix: fix assertion failure when the signal pipe overflows

### DIFF
--- a/src/unix/signal.c
+++ b/src/unix/signal.c
@@ -160,7 +160,7 @@ static void uv__signal_handler(int signum) {
     } while (r == -1 && errno == EINTR);
 
     assert(r == sizeof msg ||
-           (r == -1 && errno != EAGAIN && errno != EWOULDBLOCK));
+           (r == -1 && (errno == EAGAIN || errno == EWOULDBLOCK)));
 
     if (r != -1)
       handle->caught_signals++;


### PR DESCRIPTION
An incorrect assert() statement was causing libuv to crash when writing
to an internal signal pipe would result in EAGAIN/EWOULDBLOCK.

This commit doesn't solve the underlying issue that the signal pipe can
overflow.

This should fix joyent/node#5538
