### PR TITLE
 darwin: fix sendfile call to respect the caller's length parameter

### DIFF
--- a/src/unix/fs.c
+++ b/src/unix/fs.c
@@ -436,11 +436,14 @@ static ssize_t uv__fs_sendfile(uv_fs_t* req) {
      * non-blocking mode and not all data could be written. If a non-zero
      * number of bytes have been sent, we don't consider it an error.
      */
-    len = 0;
 
 #if defined(__FreeBSD__)
+    len = 0;
     r = sendfile(in_fd, out_fd, req->off, req->len, NULL, &len, 0);
 #else
+    /* The darwin sendfile takes len as an input for the length to send,
+     * so make sure to initialize it with the caller's value. */
+    len = req->len;
     r = sendfile(in_fd, out_fd, req->off, &len, NULL, 0);
 #endif
 


### PR DESCRIPTION
The darwin sendfile implementation uses the &len parameter as input
 and output. The code was sending 0 (not using the value of
 req->len) so the behavior wasn't what the caller was expecting.
 This makes sure to initialize len with req->len to ensure that the
 caller can send portions of a file (not always everything to the
 end of the file).

(sorry for the churn - messed up the commit message format again)
