### PR TITLE
unix: Support Android libuv standalone build

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,16 @@ Note for Linux users: compile your project with `-D_GNU_SOURCE` when you
 include `uv.h`. GYP builds take care of that automatically. If you use
 autotools, add a `AC_GNU_SOURCE` declaration to your `configure.ac`.
 
+To build for android, locate your android NDK path, then run:
+
+    source ./android-configure NDK_PATH
+    make
+
+To build for android with gyp, add "gyp" to the configuration:
+
+    source ./android-configure NDK_PATH gyp
+    make -C out
+
 ## Supported Platforms
 
 Microsoft Windows operating systems since Windows XP SP2. It can be built

--- a/android-configure
+++ b/android-configure
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+export TOOLCHAIN=$PWD/android-toolchain
+mkdir -p $TOOLCHAIN
+$1/build/tools/make-standalone-toolchain.sh \
+    --toolchain=arm-linux-androideabi-4.7 \
+    --arch=arm \
+    --install-dir=$TOOLCHAIN \
+    --platform=android-9
+export PATH=$TOOLCHAIN/bin:$PATH
+export AR=arm-linux-androideabi-ar
+export CC=arm-linux-androideabi-gcc
+export CXX=arm-linux-androideabi-g++
+export LINK=arm-linux-androideabi-g++
+export PLATFORM=android
+
+if [ $2 -a $2 == 'gyp' ]
+  then
+    ./gyp_uv -Dandroid_build=1 -Dtarget_arch=arm
+fi

--- a/common.gypi
+++ b/common.gypi
@@ -8,6 +8,13 @@
     'msvs_multi_core_compile': '0',  # we do enable multicore compiles, but not using the V8 way
     'gcc_version%': 'unknown',
     'clang%': 0,
+
+    'conditions': [
+      # Workaround for the legacy handling of android in gyp
+      ['android_build == 1', {
+        'OS': 'android',
+      }],
+    ],
   },
 
   'target_defaults': {
@@ -148,7 +155,8 @@
           [ 'OS=="solaris"', {
             'cflags': [ '-pthreads' ],
             'ldflags': [ '-pthreads' ],
-          }, {
+          }],
+          [ 'OS not in "android solaris"', {
             'cflags': [ '-pthread' ],
             'ldflags': [ '-pthread' ],
           }],

--- a/config-unix.mk
+++ b/config-unix.mk
@@ -19,7 +19,7 @@
 # IN THE SOFTWARE.
 
 E=
-CFLAGS += -g -Wall -Wextra -Wno-unused-parameter -std=c89
+CFLAGS += -g -Wall -Wextra -Wno-unused-parameter
 CPPFLAGS += -I$(SRCDIR)/src
 LDFLAGS=-lm
 
@@ -104,6 +104,18 @@ OBJS += src/unix/linux-core.o \
         src/unix/proctitle.o
 endif
 
+ifeq (android,$(PLATFORM))
+CFLAGS += -D_GNU_SOURCE
+LDFLAGS+=-ldl -lrt
+RUNNER_CFLAGS += -D_GNU_SOURCE
+OBJS += src/unix/linux-core.o \
+        src/unix/linux-inotify.o \
+        src/unix/linux-syscalls.o \
+        src/unix/proctitle.o
+else
+CFLAGS += -std=c89
+endif
+
 ifeq (freebsd,$(PLATFORM))
 HAVE_DTRACE=1
 LDFLAGS+=-lkvm
@@ -132,7 +144,9 @@ endif
 ifeq (sunos,$(PLATFORM))
 RUNNER_LDFLAGS += -pthreads
 else
+ifneq (android, $(PLATFORM))
 RUNNER_LDFLAGS += -pthread
+endif
 endif
 
 ifeq ($(HAVE_DTRACE), 1)

--- a/include/uv-private/uv-unix.h
+++ b/include/uv-private/uv-unix.h
@@ -37,7 +37,7 @@
 
 #include <semaphore.h>
 #include <pthread.h>
-#ifdef ANDROID
+#ifdef __ANDROID__
 #include "pthread-fixes.h"
 #endif
 #include <signal.h>

--- a/src/unix/linux-core.c
+++ b/src/unix/linux-core.c
@@ -36,7 +36,7 @@
 #include <fcntl.h>
 #include <time.h>
 
-#ifndef ANDROID
+#ifndef __ANDROID__
 #define HAVE_IFADDRS_H 1
 #endif
 

--- a/src/unix/thread.c
+++ b/src/unix/thread.c
@@ -281,7 +281,7 @@ int uv_cond_init(uv_cond_t* cond) {
   if (pthread_condattr_init(&attr))
     return -1;
 
-#if !defined(ANDROID)
+#if !defined(__ANDROID__)
   if (pthread_condattr_setclock(&attr, CLOCK_MONOTONIC))
     goto error2;
 #endif
@@ -336,7 +336,7 @@ int uv_cond_timedwait(uv_cond_t* cond, uv_mutex_t* mutex, uint64_t timeout) {
   timeout += uv__hrtime();
   ts.tv_sec = timeout / NANOSEC;
   ts.tv_nsec = timeout % NANOSEC;
-#if defined(ANDROID)
+#if defined(__ANDROID__)
   /*
    * The bionic pthread implementation doesn't support CLOCK_MONOTONIC,
    * but has this alternative function instead.
@@ -344,7 +344,7 @@ int uv_cond_timedwait(uv_cond_t* cond, uv_mutex_t* mutex, uint64_t timeout) {
   r = pthread_cond_timedwait_monotonic_np(cond, mutex, &ts);
 #else
   r = pthread_cond_timedwait(cond, mutex, &ts);
-#endif /* ANDROID */
+#endif /* __ANDROID__ */
 #endif
 
 


### PR DESCRIPTION
Tested most of my compilation in the previous patch on NodeJS
and extracted the patches from there. This additional patch ensures 
libuv will be capable of building standalone as well, both with gyp
and Makefiles.

Build documentation was added to the README.md file.

Some tests are failing, and I have not heavily investigated
the reasons. The failures are generally on error-conditions, and are
likely related to differences between fully POSIX-compatible
systems and android. Resolving these failures should logically
be done in separate bug reports and is currently out of scope
for my work on uv and node.
