### PR TITLE
uv: Fix the build breakage.

### DIFF
--- a/gyp_uv
+++ b/gyp_uv
@@ -93,6 +93,9 @@ if __name__ == '__main__':
   if not any(a.startswith('-Dcomponent=') for a in args):
     args.append('-Dcomponent=static_library')
 
+  if not any(a.startswith('-Dandroid_build=') for a in args):
+    args.append('-Dandroid_build=0')
+
   gyp_args = list(args)
   print gyp_args
   run_gyp(gyp_args)


### PR DESCRIPTION
Accidentally added a variable that was defined conditionally in the gyp config.

Might be better ways to resolve this, if so, please modify.
