### PR TITLE
Android build fix

### DIFF
--- a/android-configure
+++ b/android-configure
@@ -16,5 +16,5 @@ export PLATFORM=android
 
 if [ $2 -a $2 == 'gyp' ]
   then
-    ./gyp_uv -Dandroid_build=1 -Dtarget_arch=arm
+    ./gyp_uv -Dtarget_arch=arm -DOS=android
 fi

--- a/common.gypi
+++ b/common.gypi
@@ -1,6 +1,5 @@
 {
   'variables': {
-    'android_build%': 0,
     'visibility%': 'hidden',         # V8's visibility setting
     'target_arch%': 'ia32',          # set v8's target architecture
     'host_arch%': 'ia32',            # set v8's host architecture
@@ -130,7 +129,7 @@
           }]
         ]
       }],
-      ['OS in "freebsd linux openbsd solaris" or android_build == 1', {
+      ['OS in "freebsd linux openbsd solaris android"', {
         'cflags': [ '-Wall' ],
         'cflags_cc': [ '-fno-rtti', '-fno-exceptions' ],
         'target_conditions': [
@@ -150,7 +149,7 @@
             'cflags': [ '-pthreads' ],
             'ldflags': [ '-pthreads' ],
           }],
-          [ 'OS != "solaris" and android_build == 0', {
+          [ 'OS not in "solaris android"', {
             'cflags': [ '-pthread' ],
             'ldflags': [ '-pthread' ],
           }],

--- a/uv.gyp
+++ b/uv.gyp
@@ -1,6 +1,5 @@
 {
   'variables': {
-    'android_build%': 0,
     'uv_use_dtrace%': 'false',
     # uv_parent_path is the relative path to libuv in the parent project
     # this is only relevant when dtrace is enabled and libuv is a child project
@@ -22,7 +21,7 @@
           ['OS=="solaris"', {
             'cflags': [ '-pthreads' ],
           }],
-          ['OS != "solaris" and android_build == 0', {
+          ['OS not in "solaris android"', {
             'cflags': [ '-pthread' ],
           }],
         ],
@@ -162,7 +161,7 @@
               ['OS=="solaris"', {
                 'ldflags': [ '-pthreads' ],
               }],
-              ['OS != "solaris" and android_build == 0', {
+              ['OS != "solaris" and OS != "android"', {
                 'ldflags': [ '-pthread' ],
               }],
             ],
@@ -180,7 +179,7 @@
             }],
           ],
         }],
-        [ 'OS in "linux mac" or android_build == 1', {
+        [ 'OS in "linux mac android"', {
           'sources': [ 'src/unix/proctitle.c' ],
         }],
         [ 'OS=="mac"', {
@@ -216,7 +215,7 @@
             'libraries': [ '-ldl', '-lrt' ],
           },
         }],
-        [ 'android_build == 1', {
+        [ 'OS=="android"', {
           'sources': [
             'src/unix/linux-core.c',
             'src/unix/linux-inotify.c',


### PR DESCRIPTION
Since OS is transformed from android to linux, we need to ensure that conditions
specifying OS==linux are prevented from executing by additionally specifying
'and android_build=0'. 

This was done on most conditions in bnoordhuis patch, but I added a couple missed ones that broke the android build.
