### PR TITLE
build: make HAVE_DTRACE=0 should disable dtrace

### DIFF
--- a/config-unix.mk
+++ b/config-unix.mk
@@ -31,7 +31,6 @@ RUNNER_SRC=test/runner-unix.c
 RUNNER_CFLAGS=$(CFLAGS) -I$(SRCDIR)/test
 RUNNER_LDFLAGS=-L"$(CURDIR)" -luv
 
-HAVE_DTRACE=
 DTRACE_OBJS=
 DTRACE_HEADER=
 
@@ -60,13 +59,15 @@ OBJS += src/inet.o
 OBJS += src/version.o
 
 ifeq (sunos,$(PLATFORM))
-HAVE_DTRACE=1
+HAVE_DTRACE ?= 1
 CPPFLAGS += -D__EXTENSIONS__ -D_XOPEN_SOURCE=500
 LDFLAGS+=-lkstat -lnsl -lsendfile -lsocket
 # Library dependencies are not transitive.
 OBJS += src/unix/sunos.o
+ifeq (1, $(HAVE_DTRACE))
 OBJS += src/unix/dtrace.o
 DTRACE_OBJS += src/unix/core.o
+endif
 endif
 
 ifeq (aix,$(PLATFORM))
@@ -76,7 +77,7 @@ OBJS += src/unix/aix.o
 endif
 
 ifeq (darwin,$(PLATFORM))
-HAVE_DTRACE=1
+HAVE_DTRACE ?= 1
 # dtrace(1) probes contain dollar signs on OS X. Mute the warnings they
 # generate but only when CC=clang, -Wno-dollar-in-identifier-extension
 # is a clang extension.
@@ -107,7 +108,7 @@ endif
 
 ifeq (freebsd,$(PLATFORM))
 ifeq ($(shell dtrace -l 1>&2 2>/dev/null; echo $$?),0)
-HAVE_DTRACE=1
+HAVE_DTRACE ?= 1
 endif
 LDFLAGS+=-lkvm
 OBJS += src/unix/freebsd.o


### PR DESCRIPTION
actually if they set HAVE_DTRACE to anything but 1 it won't try and build with dtrace
