### PR TITLE
unix, windows: improve getaddrinfo error reporting

### DIFF
--- a/src/unix/getaddrinfo.c
+++ b/src/unix/getaddrinfo.c
@@ -28,32 +28,24 @@
 
 
 static void uv__getaddrinfo_work(struct uv__work* w) {
-  uv_getaddrinfo_t* req = container_of(w, uv_getaddrinfo_t, work_req);
+  uv_getaddrinfo_t* req;
+  int err;
 
-  req->retcode = getaddrinfo(req->hostname,
-                             req->service,
-                             req->hints,
-                             &req->res);
+  req = container_of(w, uv_getaddrinfo_t, work_req);
+  err = getaddrinfo(req->hostname, req->service, req->hints, &req->res);
+  req->retcode = uv__getaddrinfo_translate_error(err);
 }
 
 
 static void uv__getaddrinfo_done(struct uv__work* w, int status) {
   uv_getaddrinfo_t* req;
   struct addrinfo *res;
-  size_t hostlen;
 
   req = container_of(w, uv_getaddrinfo_t, work_req);
   uv__req_unregister(req->loop, req);
 
   res = req->res;
   req->res = NULL;
-
-  (void) &hostlen;  /* Silence unused variable warning. */
-  hostlen = 0;
-#if defined(__sun)
-  if (req->hostname != NULL)
-    hostlen = strlen(req->hostname);
-#endif
 
   /* See initialization in uv_getaddrinfo(). */
   if (req->hints)
@@ -71,33 +63,10 @@ static void uv__getaddrinfo_done(struct uv__work* w, int status) {
 
   if (status == -UV_ECANCELED) {
     assert(req->retcode == 0);
-    req->retcode = UV_ECANCELED;
-    uv__set_artificial_error(req->loop, UV_ECANCELED);
-    req->cb(req, -1, NULL);
-    return;
+    req->retcode = UV_EAI_CANCELED;
   }
 
-  if (req->retcode == 0) {
-    req->cb(req, 0, res);
-    return;
-  }
-
-  if (req->retcode == EAI_NONAME)
-    uv__set_sys_error(req->loop, ENOENT);
-#if defined(EAI_NODATA)  /* Newer FreeBSDs don't have EAI_NODATA. */
-  else if (req->retcode == EAI_NODATA)
-    uv__set_sys_error(req->loop, ENOENT);
-#endif
-#if defined(__sun)
-  else if (req->retcode == EAI_MEMORY && hostlen >= MAXHOSTNAMELEN)
-    uv__set_sys_error(req->loop, ENOENT);
-#endif
-  else {
-    req->loop->last_err.code = UV_EADDRINFO;
-    req->loop->last_err.sys_errno_ = req->retcode;
-  }
-
-  req->cb(req, -1, res);
+  req->cb(req, req->retcode, res);
 }
 
 

--- a/src/uv-common.c
+++ b/src/uv-common.c
@@ -28,6 +28,12 @@
 #include <stdlib.h> /* malloc */
 #include <string.h> /* memset */
 
+/* EAI_* constants. */
+#if !defined(_WIN32)
+# include <sys/types.h>
+# include <sys/socket.h>
+# include <netdb.h>
+#endif
 
 #define XX(uc, lc) case UV_##uc: return sizeof(uv_##lc##_t);
 
@@ -438,4 +444,68 @@ void uv_stop(uv_loop_t* loop) {
 
 uint64_t uv_now(uv_loop_t* loop) {
   return loop->time;
+}
+
+
+int uv__getaddrinfo_translate_error(int sys_err) {
+  switch (sys_err) {
+  case 0: return 0;
+#if defined(EAI_ADDRFAMILY)
+  case EAI_ADDRFAMILY: return UV_EAI_ADDRFAMILY;
+#endif
+#if defined(EAI_AGAIN)
+  case EAI_AGAIN: return UV_EAI_AGAIN;
+#endif
+#if defined(EAI_BADFLAGS)
+  case EAI_BADFLAGS: return UV_EAI_BADFLAGS;
+#endif
+#if defined(EAI_CANCELED)
+  case EAI_CANCELED: return UV_EAI_CANCELED;
+#endif
+#if defined(EAI_FAIL)
+  case EAI_FAIL: return UV_EAI_FAIL;
+#endif
+#if defined(EAI_FAMILY)
+  case EAI_FAMILY: return UV_EAI_FAMILY;
+#endif
+#if defined(EAI_MEMORY)
+  case EAI_MEMORY: return UV_EAI_MEMORY;
+#endif
+#if defined(EAI_NODATA)
+  case EAI_NODATA: return UV_EAI_NODATA;
+#endif
+#if defined(EAI_NONAME) && (EAI_NONAME != EAI_NODATA)
+  case EAI_NONAME: return UV_EAI_NONAME;
+#endif
+#if defined(EAI_SERVICE)
+  case EAI_SERVICE: return UV_EAI_SERVICE;
+#endif
+#if defined(EAI_SOCKTYPE)
+  case EAI_SOCKTYPE: return UV_EAI_SOCKTYPE;
+#endif
+#if defined(EAI_SYSTEM)
+  case EAI_SYSTEM: return UV_EAI_SYSTEM;
+#endif
+  }
+  return UV_EAI_UNKNOWN;
+}
+
+
+const char* uv_getaddrinfo_strerror(int err) {
+  switch (err) {
+  case 0: return "no error";
+  case UV_EAI_ADDRFAMILY: return "address family not supported";
+  case UV_EAI_AGAIN: return "temporary failure";
+  case UV_EAI_BADFLAGS: return "bad ai_flags value";
+  case UV_EAI_CANCELED: return "request canceled";
+  case UV_EAI_FAIL: return "permanent failure";
+  case UV_EAI_FAMILY: return "ai_family not supported";
+  case UV_EAI_MEMORY: return "out of memory";
+  case UV_EAI_NODATA: return "no address";
+  case UV_EAI_NONAME: return "unknown node or service";
+  case UV_EAI_SERVICE: return "service not available for socket type";
+  case UV_EAI_SOCKTYPE: return "socket type not supported";
+  case UV_EAI_SYSTEM: return "system error";
+  }
+  return "unknown error";
 }

--- a/src/uv-common.h
+++ b/src/uv-common.h
@@ -115,6 +115,7 @@ int uv__udp_recv_stop(uv_udp_t* handle);
 
 void uv__fs_poll_close(uv_fs_poll_t* handle);
 
+int uv__getaddrinfo_translate_error(int sys_err);    /* EAI_* error. */
 
 #define uv__has_active_reqs(loop)                                             \
   (QUEUE_EMPTY(&(loop)->active_reqs) == 0)

--- a/src/win/util.c
+++ b/src/win/util.c
@@ -31,7 +31,7 @@
 #include "uv.h"
 #include "internal.h"
 
-#include <Winsock2.h>
+#include <winsock2.h>
 #include <iphlpapi.h>
 #include <psapi.h>
 #include <tlhelp32.h>

--- a/test/benchmark-getaddrinfo.c
+++ b/test/benchmark-getaddrinfo.c
@@ -41,9 +41,10 @@ static int64_t end_time;
 static void getaddrinfo_initiate(uv_getaddrinfo_t* handle);
 
 
-static void getaddrinfo_cb(uv_getaddrinfo_t* handle, int status,
-    struct addrinfo* res) {
-  ASSERT(status == 0);
+static void getaddrinfo_cb(uv_getaddrinfo_t* handle,
+                          int err,
+                          struct addrinfo* res) {
+  ASSERT(err == 0);
   calls_completed++;
   if (calls_initiated < TOTAL_CALLS) {
     getaddrinfo_initiate(handle);

--- a/test/test-getaddrinfo.c
+++ b/test/test-getaddrinfo.c
@@ -37,10 +37,10 @@ static int fail_cb_called;
 
 
 static void getaddrinfo_fail_cb(uv_getaddrinfo_t* req,
-                                int status,
+                                int err,
                                 struct addrinfo* res) {
   ASSERT(fail_cb_called == 0);
-  ASSERT(status == -1);
+  ASSERT(err < 0);
   ASSERT(res == NULL);
   uv_freeaddrinfo(res);  /* Should not crash. */
   fail_cb_called++;
@@ -48,7 +48,7 @@ static void getaddrinfo_fail_cb(uv_getaddrinfo_t* req,
 
 
 static void getaddrinfo_basic_cb(uv_getaddrinfo_t* handle,
-                                 int status,
+                                 int err,
                                  struct addrinfo* res) {
   ASSERT(handle == getaddrinfo_handle);
   getaddrinfo_cbs++;
@@ -58,7 +58,7 @@ static void getaddrinfo_basic_cb(uv_getaddrinfo_t* handle,
 
 
 static void getaddrinfo_cuncurrent_cb(uv_getaddrinfo_t* handle,
-                                      int status,
+                                      int err,
                                       struct addrinfo* res) {
   int i;
   int* data = (int*)handle->data;

--- a/test/test-threadpool-cancel.c
+++ b/test/test-threadpool-cancel.c
@@ -118,10 +118,9 @@ static void fs_cb(uv_fs_t* req) {
 
 
 static void getaddrinfo_cb(uv_getaddrinfo_t* req,
-                           int status,
+                           int err,
                            struct addrinfo* res) {
-  ASSERT(UV_ECANCELED == uv_last_error(req->loop).code);
-  ASSERT(status == -1);
+  ASSERT(err == UV_EAI_CANCELED);
   ASSERT(res == NULL);
   uv_freeaddrinfo(res);  /* Should not crash. */
   getaddrinfo_cb_called++;


### PR DESCRIPTION
- Map EAI_\* constants to UV_EAI_\* constants for portability reasons.
- Have uv_getaddrinfo() hand the callback a UV_EAI_\* error code.
- Add uv_getaddrinfo_strerror() that returns a string representation
  of the UV_EAI_\* error code.

uv_getaddrinfo() can now report the full gamut of EAI_\* errors. It no
longer touches loop->last_err.

Caveats: you should not use uv_last_error() anymore in your getaddrinfo
callback. Don't pass the error code to uv_err_name() or uv_strerror(),
you'll get bogus results (or hit an assertion.)

Reviewer: @piscisaureus
