### PR TITLE
unix, windows: add extra fields to uv_stat_t

### DIFF
--- a/include/uv.h
+++ b/include/uv.h
@@ -400,9 +400,12 @@ typedef struct {
   uint64_t st_size;
   uint64_t st_blksize;
   uint64_t st_blocks;
+  uint64_t st_flags;
+  uint64_t st_gen;
   uv_timespec_t st_atim;
   uv_timespec_t st_mtim;
   uv_timespec_t st_ctim;
+  uv_timespec_t st_birthtim;
 } uv_stat_t;
 
 

--- a/src/fs-poll.c
+++ b/src/fs-poll.c
@@ -192,14 +192,18 @@ static void timer_close_cb(uv_handle_t* handle) {
 static int statbuf_eq(const uv_stat_t* a, const uv_stat_t* b) {
   return a->st_ctim.tv_nsec == b->st_ctim.tv_nsec
       && a->st_mtim.tv_nsec == b->st_mtim.tv_nsec
+      && a->st_birthtim.tv_nsec == b->st_birthtim.tv_nsec
       && a->st_ctim.tv_sec == b->st_ctim.tv_sec
       && a->st_mtim.tv_sec == b->st_mtim.tv_sec
+      && a->st_birthtim.tv_sec == b->st_birthtim.tv_sec
       && a->st_size == b->st_size
       && a->st_mode == b->st_mode
       && a->st_uid == b->st_uid
       && a->st_gid == b->st_gid
       && a->st_ino == b->st_ino
-      && a->st_dev == b->st_dev;
+      && a->st_dev == b->st_dev
+      && a->st_flags == b->st_flags
+      && a->st_gen == b->st_gen;
 }
 
 

--- a/src/unix/fs.c
+++ b/src/unix/fs.c
@@ -519,6 +519,10 @@ static void uv__to_stat(struct stat* src, uv_stat_t* dst) {
   dst->st_mtim.tv_nsec = src->st_mtimespec.tv_nsec;
   dst->st_ctim.tv_sec = src->st_ctimespec.tv_sec;
   dst->st_ctim.tv_nsec = src->st_ctimespec.tv_nsec;
+  dst->st_birthtim.tv_sec = src->st_birthtimespec.tv_sec;
+  dst->st_birthtim.tv_nsec = src->st_birthtimespec.tv_nsec;
+  dst->st_flags = src->st_flags;
+  dst->st_gen = src->st_gen;
 #elif defined(_BSD_SOURCE) || defined(_SVID_SOURCE) || defined(_XOPEN_SOURCE)
   dst->st_atim.tv_sec = src->st_atim.tv_sec;
   dst->st_atim.tv_nsec = src->st_atim.tv_nsec;
@@ -526,6 +530,20 @@ static void uv__to_stat(struct stat* src, uv_stat_t* dst) {
   dst->st_mtim.tv_nsec = src->st_mtim.tv_nsec;
   dst->st_ctim.tv_sec = src->st_ctim.tv_sec;
   dst->st_ctim.tv_nsec = src->st_ctim.tv_nsec;
+# if defined(__DragonFly__)  || \
+      defined(__FreeBSD__)    || \
+      defined(__OpenBSD__)    || \
+      defined(__NetBSD__)
+  dst->st_birthtim.tv_sec = src->st_birthtim.tv_sec;
+  dst->st_birthtim.tv_nsec = src->st_birthtim.tv_nsec;
+  dst->st_flags = src->st_flags;
+  dst->st_gen = src->st_gen;
+# else
+  dst->st_birthtim.tv_sec = src->st_ctim.tv_sec;
+  dst->st_birthtim.tv_nsec = src->st_ctim.tv_nsec;
+  dst->st_flags = 0;
+  dst->st_gen = 0;
+# endif
 #else
   dst->st_atim.tv_sec = src->st_atime;
   dst->st_atim.tv_nsec = 0;
@@ -533,6 +551,10 @@ static void uv__to_stat(struct stat* src, uv_stat_t* dst) {
   dst->st_mtim.tv_nsec = 0;
   dst->st_ctim.tv_sec = src->st_ctime;
   dst->st_ctim.tv_nsec = 0;
+  dst->st_birthtim.tv_sec = src->st_ctime;
+  dst->st_birthtim.tv_nsec = 0;
+  dst->st_flags = 0;
+  dst->st_gen = 0;
 #endif
 }
 

--- a/src/win/fs.c
+++ b/src/win/fs.c
@@ -839,6 +839,9 @@ INLINE static int fs__stat_handle(HANDLE handle, uv_stat_t* statbuf) {
   statbuf->st_blksize = 0;
   statbuf->st_blocks = 0;
 
+  statbuf->st_flags = 0;
+  statbuf->st_gen = 0;
+
   if (info.dwFileAttributes & FILE_ATTRIBUTE_REPARSE_POINT) {
     if (fs__readlink_handle(handle, NULL, &statbuf->st_size) != 0) {
       return -1;
@@ -863,6 +866,7 @@ INLINE static int fs__stat_handle(HANDLE handle, uv_stat_t* statbuf) {
   FILETIME_TO_TIMESPEC(statbuf->st_mtim, info.ftLastWriteTime);
   FILETIME_TO_TIMESPEC(statbuf->st_atim, info.ftLastAccessTime);
   FILETIME_TO_TIMESPEC(statbuf->st_ctim, info.ftCreationTime);
+  FILETIME_TO_TIMESPEC(statbuf->st_birthtim, info.ftCreationTime);
 
   statbuf->st_nlink = (info.nNumberOfLinks <= SHRT_MAX) ?
                       (short) info.nNumberOfLinks : SHRT_MAX;

--- a/test/test-fs.c
+++ b/test/test-fs.c
@@ -947,6 +947,10 @@ TEST_IMPL(fs_fstat) {
   ASSERT(s->st_mtim.tv_nsec == t.st_mtimespec.tv_nsec);
   ASSERT(s->st_ctim.tv_sec == t.st_ctimespec.tv_sec);
   ASSERT(s->st_ctim.tv_nsec == t.st_ctimespec.tv_nsec);
+  ASSERT(s->st_birthtim.tv_sec == t.st_birthtimespec.tv_sec);
+  ASSERT(s->st_birthtim.tv_nsec == t.st_birthtimespec.tv_nsec);
+  ASSERT(s->st_flags == t.st_flags);
+  ASSERT(s->st_gen == t.st_gen);
 #elif defined(_BSD_SOURCE) || defined(_SVID_SOURCE) || defined(_XOPEN_SOURCE)
   ASSERT(s->st_atim.tv_sec == t.st_atim.tv_sec);
   ASSERT(s->st_atim.tv_nsec == t.st_atim.tv_nsec);
@@ -954,6 +958,15 @@ TEST_IMPL(fs_fstat) {
   ASSERT(s->st_mtim.tv_nsec == t.st_mtim.tv_nsec);
   ASSERT(s->st_ctim.tv_sec == t.st_ctim.tv_sec);
   ASSERT(s->st_ctim.tv_nsec == t.st_ctim.tv_nsec);
+# if defined(__DragonFly__)  || \
+      defined(__FreeBSD__)    || \
+      defined(__OpenBSD__)    || \
+      defined(__NetBSD__)
+  ASSERT(s->st_birthtim.tv_sec == t.st_birthtim.tv_sec);
+  ASSERT(s->st_birthtim.tv_nsec == t.st_birthtim.tv_nsec);
+  ASSERT(s->st_flags == t.st_flags);
+  ASSERT(s->st_gen == t.st_gen);
+# endif
 #else
   ASSERT(s->st_atim.tv_sec == t.st_atime);
   ASSERT(s->st_atim.tv_nsec == 0);


### PR DESCRIPTION
They are BSD-isms. st_flags and st_gen are zeroed on non-BSD systems and st_birthtim is set to st_ctim.
