### PR TITLE
unix, windows, darwin : Implemented uv channels

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -141,6 +141,7 @@ test_run_tests_SOURCES = test/blackhole-server.c \
                          test/test-udp-options.c \
                          test/test-udp-send-and-recv.c \
                          test/test-util.c \
+                         test/test-channel.c \
                          test/test-walk-handles.c
 test_run_tests_LDADD = libuv.la
 

--- a/checksparse.sh
+++ b/checksparse.sh
@@ -160,6 +160,7 @@ test/test-udp-options.c
 test/test-udp-send-and-recv.c
 test/test-util.c
 test/test-walk-handles.c
+test/test-channel.c
 "
 
 case `uname -s` in

--- a/include/uv.h
+++ b/include/uv.h
@@ -221,7 +221,7 @@ typedef struct uv_work_s uv_work_t;
 /* None of the above. */
 typedef struct uv_cpu_info_s uv_cpu_info_t;
 typedef struct uv_interface_address_s uv_interface_address_t;
-
+typedef struct uv_chan_s uv_chan_t;
 
 typedef enum {
   UV_RUN_DEFAULT = 0,
@@ -1999,6 +1999,27 @@ union uv_any_req {
 };
 #undef XX
 
+struct uv_chan_s {
+  uv_mutex_t mutex;
+  uv_cond_t cond;
+  void* q[2];
+};
+
+/*
+ * A channel provides a mechanism for concurrently executing threads to communicate by passing values.
+ * Given a uv_chan_t instance, any thread can send or receive data. Data will be send to all the receivers
+ * in the channel. The first one who reads data will get it and all other receivers will still wait. User don't
+ * have to explicitly lock when sending or receiving data.
+ *
+ * Receivers always block until there is data to receive.
+ *
+ * A channel can be closed with uv_chan_destroy
+ *
+ */
+UV_EXTERN int uv_chan_init(uv_chan_t* chan);
+UV_EXTERN void uv_chan_send(uv_chan_t* chan, void* data);
+UV_EXTERN void* uv_chan_receive(uv_chan_t* chan);
+UV_EXTERN void uv_chan_destroy(uv_chan_t* chan);
 
 struct uv_loop_s {
   /* User data - use this for whatever. */

--- a/src/uv-common.c
+++ b/src/uv-common.c
@@ -472,3 +472,54 @@ int uv__getaddrinfo_translate_error(int sys_err) {
   assert(!"unknown EAI_* error code");
   abort();
 }
+
+typedef struct {
+  void* data;
+  uv_req_type type;
+  void* active_queue[2];
+} uv__chan_item_t;
+
+int uv_chan_init(uv_chan_t* chan) {
+  int r = uv_mutex_init (&chan->mutex);
+  if (r == -1)
+    return r;
+
+  QUEUE_INIT(&chan->q);
+
+  return uv_cond_init (&chan->cond);
+}
+
+void uv_chan_send(uv_chan_t* chan, void* data) {
+  uv__chan_item_t* item = malloc(sizeof(uv__chan_item_t));
+  item->data = data;
+
+  uv_mutex_lock (&chan->mutex);
+  QUEUE_INSERT_TAIL(&chan->q, &item->active_queue);
+  uv_cond_signal (&chan->cond);
+  uv_mutex_unlock (&chan->mutex);
+}
+
+void* uv_chan_receive(uv_chan_t* chan) {
+  uv__chan_item_t* item;
+  QUEUE* head;
+  void* data = NULL;
+
+  uv_mutex_lock (&chan->mutex);
+  while (QUEUE_EMPTY(&chan->q)) {
+    uv_cond_wait (&chan->cond, &chan->mutex);
+  }
+
+  head = QUEUE_HEAD (&chan->q);
+  item = QUEUE_DATA (head, uv__chan_item_t, active_queue);
+  data = item->data;
+  QUEUE_REMOVE (head);
+  free (item);
+  uv_mutex_unlock (&chan->mutex);
+  return data;
+}
+
+void uv_chan_destroy(uv_chan_t* chan) {
+  uv_cond_destroy (&chan->cond);
+  uv_mutex_destroy (&chan->mutex);
+}
+

--- a/test/test-channel.c
+++ b/test/test-channel.c
@@ -1,0 +1,94 @@
+/* Copyright Joyent, Inc. and other Node contributors. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to
+ * deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+
+#include "uv.h"
+#include "task.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+
+static void worker(void* arg) {
+  int i;
+  char* string;
+  uv_chan_t* chan = arg;
+
+  for (i = 0; i < 10; i++) {
+    string = malloc(sizeof(char) * 2);
+    sprintf(string, "%d", i);
+    uv_chan_send (chan, string);
+    uv_sleep (10);
+  }
+
+  uv_chan_send (chan, NULL);
+}
+
+TEST_IMPL(message_passing_with_channels) {
+  int threads_exited = 0, messages_received = 0;
+  char* message;
+  uv_chan_t chan;
+  uv_thread_t thread1, thread2;
+
+  ASSERT(0 == uv_chan_init (&chan));
+  ASSERT(0 == uv_thread_create(&thread1, worker, &chan));
+  ASSERT(0 == uv_thread_create(&thread2, worker, &chan));
+
+  while (threads_exited < 2) {
+    message = uv_chan_receive(&chan);
+    if (message == NULL)
+      ++threads_exited;
+    else
+      ++messages_received;
+  }
+
+  ASSERT(20 == messages_received);
+
+  uv_chan_destroy (&chan);
+
+  return 0;
+}
+
+static const char* message = "Done";
+
+static void worker1(void* arg) {
+  uv_chan_t* chan = arg;
+  uv_sleep (1000);
+  uv_chan_send (chan, message);
+}
+
+TEST_IMPL(uv_chan_receive_should_block_when_no_data_available) {
+  int data_received = 0;
+  uv_chan_t chan;
+  uv_thread_t thread;
+  void* received;
+
+  ASSERT(0 == uv_chan_init (&chan));
+  ASSERT(0 == uv_thread_create (&thread, worker1, &chan));
+
+  received = uv_chan_receive (&chan);
+  ASSERT(0 == strcmp(message, received));
+
+  uv_chan_destroy (&chan);
+
+  return 0;
+}
+

--- a/test/test-list.h
+++ b/test/test-list.h
@@ -212,6 +212,8 @@ TEST_DECLARE   (poll_duplex)
 TEST_DECLARE   (poll_unidirectional)
 TEST_DECLARE   (poll_close)
 TEST_DECLARE   (ip6_addr_link_local)
+TEST_DECLARE   (message_passing_with_channels)
+TEST_DECLARE   (uv_chan_receive_should_block_when_no_data_available)
 #ifdef _WIN32
 TEST_DECLARE   (spawn_detect_pipe_name_collisions_on_windows)
 TEST_DECLARE   (argument_escaping)
@@ -501,6 +503,8 @@ TASK_LIST_START
   TEST_ENTRY  (strlcat)
   TEST_ENTRY  (dlerror)
   TEST_ENTRY  (ip6_addr_link_local)
+  TEST_ENTRY  (message_passing_with_channels)
+  TEST_ENTRY  (uv_chan_receive_should_block_when_no_data_available)
 #if 0
   /* These are for testing the test runner. */
   TEST_ENTRY  (fail_always)

--- a/uv.gyp
+++ b/uv.gyp
@@ -379,6 +379,7 @@
         'test/test-dlerror.c',
         'test/test-udp-multicast-ttl.c',
         'test/test-ip6-addr.c',
+        'test/test-channel.c',
       ],
       'conditions': [
         [ 'OS=="win"', {


### PR DESCRIPTION
# Introduction

This commit attempts to implement channels (something very similar to what golang has) to `libuv`. 

A channel provides a mechanism for two concurrently executing functions to communicate by passing any value. This value will be passed to all the receivers that the channel has.  This simplifies message passing between worker threads.

Channel internally holds a mutex and synchronizes the messages it gets. Because of this, user don't have to acquire a lock when sending or receiving from channels.
# Example

``` c
#include "include/uv.h" 
#include <stdio.h>
#include <string.h>

static void worker(void* arg) {
    int i;
    char *string;
    uv_chan_t* chan = arg;

    for (i = 0; i < 10; i++) {
        string = malloc(sizeof(char) * 2);
        sprintf(string, "%d", i);
        uv_chan_send (chan, string);
    }

    uv_chan_send (chan, NULL);
}

int main() {
    uv_thread_t thread1, thread2;
    uv_chan_t chan;
    char *message;
    int count = 0;

    uv_chan_init (&chan);
    uv_thread_create(&thread1, worker, &chan);
    uv_thread_create(&thread2, worker, &chan);

    while(count < 2) {
        message = uv_chan_receive (&chan);
        if (message == NULL)
            count++;
        printf ("%s\n", message);
        free (message);
    }

    uv_thread_join(&thread1);
    uv_thread_join(&thread2);
    uv_chan_destroy (&chan);
    return 0;
}
```
# Future work

This is just a first cut version of the channels. We could also implement the following,
- Specifying maximum size of elements that a channel can hold. If more elements that this is queued, `uv_chan_send` will block until someone reads from it. 
- To avoid multiple threads updating same instance of data, data needs to be deep copied before sending to the channel. Currently everyone who uses `uv_chan_send` has to remember to deep copy the data. This can be simplified by adding a `copy_cb` to the `uv_chan_t` which gets called whenever `uv_chan_send` is called. This callback can deep copy data and return pointer to the new instance. This way, user has to configure it only while creating the channel and while sending, callback will take care of deep copying. 

This idea is largely inspired from the golang's channels. I believe this simplifies communication between threads.

Let me know the feedback.
