### PR TITLE
unix: Expose tcp start and stop externally

### DIFF
--- a/include/uv.h
+++ b/include/uv.h
@@ -765,6 +765,14 @@ UV_EXTERN int uv_tcp_connect(uv_connect_t* req, uv_tcp_t* handle,
 UV_EXTERN int uv_tcp_connect6(uv_connect_t* req, uv_tcp_t* handle,
     struct sockaddr_in6 address, uv_connect_cb cb);
 
+/*
+ * Used for turning off the acceptance of new TCP connections for
+ * handling a graceful shutdown.
+ */
+
+UV_EXTERN void uv_tcp_start(uv_tcp_t* tcp);
+UV_EXTERN void uv_tcp_stop(uv_tcp_t* tcp);
+
 /* uv_connect_t is a subclass of uv_req_t */
 struct uv_connect_s {
   UV_REQ_FIELDS

--- a/src/unix/tcp.c
+++ b/src/unix/tcp.c
@@ -323,6 +323,13 @@ int uv_tcp_simultaneous_accepts(uv_tcp_t* handle, int enable) {
   return 0;
 }
 
+void uv_tcp_start(uv_tcp_t* tcp) {
+  uv__io_start(tcp->loop, &tcp->io_watcher, UV__POLLIN);
+}
+
+void uv_tcp_stop(uv_tcp_t* tcp) {
+  uv__io_stop(tcp->loop, &tcp->io_watcher, UV__POLLIN);
+} 
 
 void uv__tcp_close(uv_tcp_t* handle) {
   uv__stream_close((uv_stream_t*)handle);


### PR DESCRIPTION
Exposing these to allow hooking into and stopping tcp requests on a connection while allowing current connections to continue.

I didn't patch the Win32 files because I'm not a windows guy. I'll be happy to add it for feature parity if someone can give me a hand.

_This request will also have a counterpart in Node land to expose this API to JS_
