### PR TITLE
unix: Close signal_lock_pipe FDs on unload

### DIFF
--- a/src/unix/signal.c
+++ b/src/unix/signal.c
@@ -62,6 +62,17 @@ static void uv__signal_global_init(void) {
     abort();
 }
 
+__attribute__((destructor))
+static void uv__signal_global_dtor(void) {
+  int i;
+  int *fdp = uv__signal_lock_pipefd;
+
+  for (i = 0; i < 2; i++) {
+    if (fdp[i] > -1) {
+        close(fdp[i]);
+    }
+  }
+}
 
 void uv__signal_global_once_init(void) {
   pthread_once(&uv__signal_global_init_guard, uv__signal_global_init);


### PR DESCRIPTION
If libuv is being dynamically loaded (and unloaded) as a module, the
global initialization routines actually run multiple times. This allows
the FDs to be closed when the library is unloaded.

(I've signed the CLA already)
