### PR TITLE
build: use -pthread on sunos

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -31,6 +31,10 @@ libuv_la_SOURCES = src/fs-poll.c \
                    src/uv-common.h \
                    src/version.c
 
+if SUNOS
+libuv_la_CFLAGS += -pthread
+endif
+
 if WINNT
 
 include_HEADERS += include/uv-win.h include/tree.h


### PR DESCRIPTION
When building on sunos with autoconf make sure to specify -pthread
otherwise there will be race conditions with errno and etc

@bnoordhuis
