### PR TITLE
Add Flag to Spawn Child Process with New Process Group ID but the Same Session ID

### DIFF
--- a/include/uv.h
+++ b/include/uv.h
@@ -1478,7 +1478,14 @@ enum uv_process_flags {
    * option is only meaningful on Windows systems. On unix it is silently
    * ignored.
    */
-  UV_PROCESS_WINDOWS_HIDE = (1 << 4)
+  UV_PROCESS_WINDOWS_HIDE = (1 << 4),
+  /*
+   * Spawn a child process in a new process group - this will make the process
+   * a group leader, but the process will remain in the same session as the
+   * parent. This behaviour is required for shell processes that wish to 
+   * use job-control, and have their children share the attached TTY.
+   */
+  UV_PROCESS_SETPGID = (1 << 5)    
 };
 
 /*

--- a/src/unix/process.c
+++ b/src/unix/process.c
@@ -280,6 +280,9 @@ static void uv__process_child_init(const uv_process_options_t* options,
 
   if (options->flags & UV_PROCESS_DETACHED)
     setsid();
+  
+  if (options->flags & UV_PROCESS_SETPGID)
+    setpgid(0,0);
 
   for (fd = 0; fd < stdio_count; fd++) {
     close_fd = pipes[fd][0];


### PR DESCRIPTION
I am working on a primitive shell in node that has full-fledged job-control. Proper job control requires being able to spawn child processes with the same session id, but in a new process group. Currently libuv only supports flagging a child for complete detachment via `UV_PROCESS_DETACHED`.

A bit on TTYs and why this is necessary. I apologize if this is all familiar.
## Background

Whenever you log into a shell, such as bash, there is always a controlling TTY for the session. That controlling TTY is just a file descriptor for a character device e.g. `/dev/console`. The reason you see the output from a command like `ls` is because after bash forks, it keeps STDOUT/STDERR attached to the controlling TTY before calling `exec` on `ls`. Thus the TTY is being shared by almost every process that is a direct or indirect child of your login session.

In order to calm the madness, the TTY drive has the concept of a foreground process group. Only processes in the foreground process group are allowed to read and write to the TTYs character device. If a background process tries to read or write to the TTY it will be sent `SIGTTIN` or `SIGTTOUT`. The `SIGTTOUT` signal can be ignored, but ignoring `SIGTTIN` will result in an `EIO` read error.

The foreground process group also lets the line-discipline decide which processes should be sent control signals like `SIGINT` whenever it processes a `^C` character.
## Problem

The problem is that the system call ([tcsetpgrp](http://linux.die.net/man/3/tcsetpgrp)) for setting foreground process groups can _only_ be done on process groups in the same session. Thus using `UV_PROCESS_DETACHED` will cause `tcsetpgrp` to error.
