### PR TITLE
unix: close signal pipe fds when last loop is done

### DIFF
--- a/src/unix/internal.h
+++ b/src/unix/internal.h
@@ -179,11 +179,13 @@ void uv__run_timers(uv_loop_t* loop);
 int uv__next_timeout(const uv_loop_t* loop);
 
 /* signal */
+int uv__signal_global_init(void);
+void uv__signal_global_destroy(void);
 void uv__signal_close(uv_signal_t* handle);
-void uv__signal_global_once_init(void);
 void uv__signal_loop_cleanup(uv_loop_t* loop);
 
 /* thread pool */
+void uv__threadpool_global_destroy(void);
 void uv__work_submit(uv_loop_t* loop,
                      struct uv__work *w,
                      void (*work)(struct uv__work *w),

--- a/src/unix/threadpool.c
+++ b/src/unix/threadpool.c
@@ -129,7 +129,10 @@ static void init_once(void) {
 }
 
 
-UV_DESTRUCTOR(static void cleanup(void)) {
+/* This function is called with the global loop lock held when the last
+ * event loop has been destroyed.
+ */
+void uv__threadpool_global_destroy(void) {
   unsigned int i;
 
   if (initialized == 0)

--- a/test/runner-win.c
+++ b/test/runner-win.c
@@ -367,3 +367,12 @@ void rewind_cursor() {
 void uv_sleep(int msec) {
   Sleep(msec);
 }
+
+
+void before_main_hook(task_entry_t* task) {
+}
+
+
+int after_main_hook(task_entry_t* task, int status) {
+  return status;
+}

--- a/test/runner-win.h
+++ b/test/runner-win.h
@@ -19,6 +19,9 @@
  * IN THE SOFTWARE.
  */
 
+#ifndef TEST_RUNNER_WIN_H
+#define TEST_RUNNER_WIN_H
+
 /* Don't complain about _snprintf being insecure. */
 #define _CRT_SECURE_NO_WARNINGS
 
@@ -41,3 +44,5 @@ typedef struct {
   HANDLE stdio_out;
   char *name;
 } process_info_t;
+
+#endif  /* TEST_RUNNER_WIN_H */

--- a/test/runner.c
+++ b/test/runner.c
@@ -213,7 +213,8 @@ int run_test(const char* test,
   /* If it's a helper the user asks for, start it directly. */
   for (task = TASKS; task->main; task++) {
     if (task->is_helper && strcmp(test, task->process_name) == 0) {
-      return task->main();
+      before_main_hook(task);
+      return after_main_hook(task, task->main());
     }
   }
 
@@ -388,13 +389,12 @@ out:
  */
 int run_test_part(const char* test, const char* part) {
   task_entry_t* task;
-  int r;
 
   for (task = TASKS; task->main; task++) {
     if (strcmp(test, task->task_name) == 0 &&
         strcmp(part, task->process_name) == 0) {
-      r = task->main();
-      return r;
+      before_main_hook(task);
+      return after_main_hook(task, task->main());
     }
   }
 

--- a/test/runner.h
+++ b/test/runner.h
@@ -164,6 +164,12 @@ void process_cleanup(process_info_t *p);
 /* Move the console cursor one line up and back to the first column. */
 void rewind_cursor(void);
 
+/* Run right before task->main() is entered. */
+void before_main_hook(task_entry_t* task);
+
+/* Run right after task->main() returns. |status| is its return code. */
+int after_main_hook(task_entry_t* task, int status);
+
 /* trigger output as tap */
 extern int tap_output;
 

--- a/test/test-embed.c
+++ b/test/test-embed.c
@@ -135,5 +135,6 @@ TEST_IMPL(embed) {
   ASSERT(embed_timer_called == 1);
 #endif
 
+  MAKE_VALGRIND_HAPPY();
   return 0;
 }

--- a/test/test-fs.c
+++ b/test/test-fs.c
@@ -1732,8 +1732,9 @@ TEST_IMPL(fs_readdir_file) {
 
 TEST_IMPL(fs_open_dir) {
   const char* path;
+  uv_file file;
   uv_fs_t req;
-  int r, file;
+  int r;
 
   path = ".";
   loop = uv_default_loop();
@@ -1742,7 +1743,7 @@ TEST_IMPL(fs_open_dir) {
   ASSERT(r >= 0);
   ASSERT(req.result >= 0);
   ASSERT(req.ptr == NULL);
-  file = r;
+  file = req.result;
   uv_fs_req_cleanup(&req);
 
   r = uv_fs_close(loop, &req, file, NULL);
@@ -1754,6 +1755,10 @@ TEST_IMPL(fs_open_dir) {
   ASSERT(open_cb_count == 0);
   uv_run(loop, UV_RUN_DEFAULT);
   ASSERT(open_cb_count == 1);
+
+  ASSERT(0 == uv_fs_close(loop, &close_req, file, close_cb));
+  ASSERT(0 == uv_run(loop, UV_RUN_DEFAULT));
+  ASSERT(1 == close_cb_count);
 
   MAKE_VALGRIND_HAPPY();
   return 0;

--- a/test/test-fs.c
+++ b/test/test-fs.c
@@ -1651,6 +1651,10 @@ TEST_IMPL(fs_futime) {
   uv_run(loop, UV_RUN_DEFAULT);
   ASSERT(futime_cb_count == 1);
 
+  ASSERT(0 == uv_fs_close(loop, &close_req, file, close_cb));
+  ASSERT(0 == uv_run(loop, UV_RUN_DEFAULT));
+  ASSERT(1 == close_cb_count);
+
   /* Cleanup. */
   unlink(path);
 

--- a/test/test-loop-stop.c
+++ b/test/test-loop-stop.c
@@ -69,5 +69,6 @@ TEST_IMPL(loop_stop) {
   ASSERT(timer_called == 10);
   ASSERT(prepare_called == 10);
 
+  MAKE_VALGRIND_HAPPY();
   return 0;
 }

--- a/test/test-run-nowait.c
+++ b/test/test-run-nowait.c
@@ -42,5 +42,6 @@ TEST_IMPL(run_nowait) {
   ASSERT(r != 0);
   ASSERT(timer_called == 0);
 
+  MAKE_VALGRIND_HAPPY();
   return 0;
 }

--- a/test/test-tcp-bind-error.c
+++ b/test/test-tcp-bind-error.c
@@ -186,13 +186,13 @@ TEST_IMPL(tcp_bind_localhost_ok) {
 
 
 TEST_IMPL(tcp_listen_without_bind) {
-  int r;
   uv_tcp_t server;
 
-  r = uv_tcp_init(uv_default_loop(), &server);
-  ASSERT(r == 0);
-  r = uv_listen((uv_stream_t*)&server, 128, NULL);
-  ASSERT(r == 0);
+  ASSERT(0 == uv_tcp_init(uv_default_loop(), &server));
+  ASSERT(0 == uv_listen((uv_stream_t*) &server, 128, NULL));
+
+  uv_close((uv_handle_t*) &server, NULL);
+  ASSERT(0 == uv_run(uv_default_loop(), UV_RUN_DEFAULT));
 
   MAKE_VALGRIND_HAPPY();
   return 0;

--- a/test/test-tcp-bind-error.c
+++ b/test/test-tcp-bind-error.c
@@ -171,14 +171,13 @@ TEST_IMPL(tcp_bind_error_inval) {
 TEST_IMPL(tcp_bind_localhost_ok) {
   struct sockaddr_in addr;
   uv_tcp_t server;
-  int r;
 
   ASSERT(0 == uv_ip4_addr("127.0.0.1", TEST_PORT, &addr));
+  ASSERT(0 == uv_tcp_init(uv_default_loop(), &server));
+  ASSERT(0 == uv_tcp_bind(&server, (const struct sockaddr*) &addr));
 
-  r = uv_tcp_init(uv_default_loop(), &server);
-  ASSERT(r == 0);
-  r = uv_tcp_bind(&server, (const struct sockaddr*) &addr);
-  ASSERT(r == 0);
+  uv_close((uv_handle_t*) &server, NULL);
+  ASSERT(0 == uv_run(uv_default_loop(), UV_RUN_DEFAULT));
 
   MAKE_VALGRIND_HAPPY();
   return 0;

--- a/test/test-tcp-bind6-error.c
+++ b/test/test-tcp-bind6-error.c
@@ -147,14 +147,13 @@ TEST_IMPL(tcp_bind6_error_inval) {
 TEST_IMPL(tcp_bind6_localhost_ok) {
   struct sockaddr_in6 addr;
   uv_tcp_t server;
-  int r;
 
   ASSERT(0 == uv_ip6_addr("::1", TEST_PORT, &addr));
+  ASSERT(0 == uv_tcp_init(uv_default_loop(), &server));
+  ASSERT(0 == uv_tcp_bind(&server, (const struct sockaddr*) &addr));
 
-  r = uv_tcp_init(uv_default_loop(), &server);
-  ASSERT(r == 0);
-  r = uv_tcp_bind(&server, (const struct sockaddr*) &addr);
-  ASSERT(r == 0);
+  uv_close((uv_handle_t*) &server, NULL);
+  ASSERT(0 == uv_run(uv_default_loop(), UV_RUN_DEFAULT));
 
   MAKE_VALGRIND_HAPPY();
   return 0;

--- a/test/test-tcp-close.c
+++ b/test/test-tcp-close.c
@@ -131,6 +131,9 @@ TEST_IMPL(tcp_close) {
   ASSERT(write_cb_called == NUM_WRITE_REQS);
   ASSERT(close_cb_called == 1);
 
+  uv_close((uv_handle_t*) &tcp_server, NULL);
+  ASSERT(0 == uv_run(loop, UV_RUN_DEFAULT));
+
   MAKE_VALGRIND_HAPPY();
   return 0;
 }

--- a/test/test-udp-options.c
+++ b/test/test-udp-options.c
@@ -83,6 +83,9 @@ TEST_IMPL(udp_options) {
   r = uv_run(loop, UV_RUN_DEFAULT);
   ASSERT(r == 0);
 
+  uv_close((uv_handle_t*) &h, NULL);
+  ASSERT(0 == uv_run(loop, UV_RUN_DEFAULT));
+
   MAKE_VALGRIND_HAPPY();
   return 0;
 }


### PR DESCRIPTION
Fixes #875.

Adds a leaked file descriptor check to the test runner that scans for open file descriptors when the test is done.  Most of the other commits are fix-ups that plug fd leaks in the tests.  I just noticed that the commit log that adds the check is a bit terse, I'll fix that up before landing this.

@indutny or @saghul, feel free to review it if you like.
