### PR TITLE
fsevents: i18n improvements for mac file paths

### DIFF
--- a/src/unix/fsevents.c
+++ b/src/unix/fsevents.c
@@ -340,7 +340,7 @@ static void uv__fsevents_reschedule(uv_fs_event_t* handle) {
 
       assert(curr->realpath != NULL);
       paths[i] = CFStringCreateWithFileSystemRepresentation(NULL,
-                                            curr->realpath);
+                                                            curr->realpath);
       if (paths[i] == NULL)
         abort();
     }

--- a/src/unix/fsevents.c
+++ b/src/unix/fsevents.c
@@ -339,9 +339,8 @@ static void uv__fsevents_reschedule(uv_fs_event_t* handle) {
       curr = ngx_queue_data(q, uv_fs_event_t, cf_member);
 
       assert(curr->realpath != NULL);
-      paths[i] = CFStringCreateWithCString(NULL,
-                                           curr->realpath,
-                                           CFStringGetSystemEncoding());
+      paths[i] = CFStringCreateWithFileSystemRepresentation(NULL,
+                                            curr->realpath);
       if (paths[i] == NULL)
         abort();
     }


### PR DESCRIPTION
Fix a bug monitoring folders with japanese characters in the path.
