### PR TITLE
unix: return exec errors from uv_spawn, not async

### DIFF
--- a/include/uv-unix.h
+++ b/include/uv-unix.h
@@ -287,7 +287,6 @@ typedef struct {
 
 #define UV_PROCESS_PRIVATE_FIELDS                                             \
   void* queue[2];                                                             \
-  int errorno;                                                                \
   int status;                                                                 \
 
 #define UV_FS_PRIVATE_FIELDS                                                  \

--- a/include/uv-win.h
+++ b/include/uv-win.h
@@ -533,7 +533,6 @@ RB_HEAD(uv_timer_tree_s, uv_timer_s);
     UV_REQ_FIELDS                                                             \
   } exit_req;                                                                 \
   BYTE* child_stdio_buffer;                                                   \
-  int spawn_error;                                                            \
   int exit_signal;                                                            \
   HANDLE wait_handle;                                                         \
   HANDLE process_handle;                                                      \

--- a/include/uv.h
+++ b/include/uv.h
@@ -1504,7 +1504,17 @@ struct uv_process_s {
   UV_PROCESS_PRIVATE_FIELDS
 };
 
-/* Initializes uv_process_t and starts the process. */
+/*
+ * Initializes the uv_process_t and starts the process. If the process is
+ * successfully spawned, then this function will return 0. Otherwise, the
+ * negative error code corresponding to the reason it couldn't spawn is
+ * returned.
+ *
+ * Possible reasons for failing to spawn would include (but not be limited to)
+ * the file to execute not existing, not having permissions to use the setuid or
+ * setgid specified, or not having enough memory to allocate for the new
+ * process.
+ */
 UV_EXTERN int uv_spawn(uv_loop_t* loop,
                        uv_process_t* handle,
                        const uv_process_options_t* options);


### PR DESCRIPTION
If spawning a process fails due to an exec() failure (but it succeeded in
forking), then this should be considered a spawn failure instead of an
asynchronous termination of the process. This allows to check for common exec()
failure conditions such as a bad path quickly instead of having to rely on
keeping track of the async callback.

Additionally, the meaning of the two fields returned in the callback are now
exactly what they advertise to be. The process exit argument is not one of two
values depending on what happened to the child.

Closes #978
