### PR TITLE
unix: set close-on-exec flag on received fds

### DIFF
--- a/src/unix/internal.h
+++ b/src/unix/internal.h
@@ -139,6 +139,7 @@ int uv__close(int fd);
 int uv__cloexec(int fd, int set);
 int uv__socket(int domain, int type, int protocol);
 int uv__dup(int fd);
+ssize_t uv__recvmsg(int fd, struct msghdr *msg, int flags);
 void uv__make_close_pending(uv_handle_t* handle);
 
 void uv__io_init(uv__io_t* w, uv__io_cb cb, int fd);

--- a/src/unix/stream.c
+++ b/src/unix/stream.c
@@ -1007,7 +1007,7 @@ static void uv__read(uv_stream_t* stream) {
       msg.msg_control = (void*)  cmsg_space;
 
       do {
-        nread = recvmsg(uv__stream_fd(stream), &msg, 0);
+        nread = uv__recvmsg(uv__stream_fd(stream), &msg, 0);
       }
       while (nread < 0 && errno == EINTR);
     }


### PR DESCRIPTION
Set the close-on-exec flag on file descriptors that we've received with
recvmsg() so we don't leak them when calling fork() afterwards.

On Linux, we use the MSG_CMSG_CLOEXEC flag when supported (2.6.23 and
up.)

On older Linux versions and other platforms, we walk the received file
descriptors and set the close-on-exec flag for each fd manually.  That
won't entirely avoid race conditions when other threads call fork() or
clone() but at least we're less likely to leak file descriptors now.
