### PR TITLE
implement UV_EXTERN_VISIBILITY_DEFAULT for GCC and Clang

### DIFF
--- a/common.gypi
+++ b/common.gypi
@@ -154,7 +154,7 @@
             'cflags': [ '-pthread' ],
             'ldflags': [ '-pthread' ],
           }],
-          [ 'visibility=="hidden" and (clang==1 or gcc_version >= 40)', {
+          [ '(clang==1 or gcc_version >= 40)', {
             'cflags': [ '-fvisibility=hidden' ],
           }],
         ],
@@ -202,6 +202,11 @@
        'cflags': [ '-fno-omit-frame-pointer' ],
        # pull in V8's postmortem metadata
        'ldflags': [ '-Wl,-z,allextract' ]
+     }],
+     ['visibility=="default"', {
+       'defines': [
+         'UV_EXTERN_VISIBILITY_DEFAULT',
+       ]
      }],
     ],
   },

--- a/include/uv.h
+++ b/include/uv.h
@@ -39,7 +39,7 @@ extern "C" {
     /* Building static library. */
 #   define UV_EXTERN /* nothing */
 # endif
-#elif __GNUC__ >= 4
+#elif __GNUC__ >= 4 && defined(UV_EXTERN_VISIBILITY_DEFAULT)
 # define UV_EXTERN __attribute__((visibility("default")))
 #else
 # define UV_EXTERN /* nothing */


### PR DESCRIPTION
Previously, the `visibility` variable in common.gypi only controlled whether GCC or Clang builds would build with -fvisibility=hidden, but unfortunately this effect was negated by a define in uv.h setting UV_EXTERN to mark symbols with `default` visibility. This change sets -fvisibility=hidden as default and adds a define for setting UV_EXTERN to `default` visibility, which also enables building with `hidden` visibility, for example as a static library.
