### PR TITLE
build: check if pkg-config is installed

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -45,12 +45,11 @@ AM_CONDITIONAL([NETBSD],  [AS_CASE([$host_os], [netbsd*],  [true], [false])])
 AM_CONDITIONAL([OPENBSD], [AS_CASE([$host_os], [openbsd*], [true], [false])])
 AM_CONDITIONAL([SUNOS],   [AS_CASE([$host_os], [solaris*], [true], [false])])
 AM_CONDITIONAL([WINNT],   [AS_CASE([$host_os], [mingw*],   [true], [false])])
-PKG_PROG_PKG_CONFIG([0.20])
-AM_CONDITIONAL([HAVE_PKG_CONFIG], [test "x$PKG_CONFIG" != "x"])
-AC_SUBST(HAVE_PKG_CONFIG)
 PANDORA_ENABLE_DTRACE
-AS_IF([test "x$PKG_CONFIG" != "x"], [
-	AC_CONFIG_FILES([libuv.pc])
+AC_CHECK_PROG(PKG_CONFIG, pkg-config, yes)
+AM_CONDITIONAL([HAVE_PKG_CONFIG], [test "x$PKG_CONFIG" = "xyes"])
+AS_IF([test "x$PKG_CONFIG" = "xyes"], [
+    AC_CONFIG_FILES([libuv.pc])
 ])
 AC_CONFIG_FILES([Makefile])
 AC_OUTPUT


### PR DESCRIPTION
My autotools-fu is not very strong,but lets see if the build slaves turn green.
