### PR TITLE
doc: add readme link to all projects that use libuv.

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ libuv is a multi-platform support library with a focus on asynchronous I/O. It
 was primarily developed for use by [Node.js](http://nodejs.org), but it's also
 used by Mozilla's [Rust language](http://www.rust-lang.org/),
 [Luvit](http://luvit.io/), [Julia](http://julialang.org/),
-[pyuv](https://crate.io/packages/pyuv/), and others.
+[pyuv](https://crate.io/packages/pyuv/), and [others](https://github.com/joyent/libuv/wiki/Projects-that-use-libuv).
 
 ## Feature highlights
 


### PR DESCRIPTION
All examples can be then dynamically added in the documentation without the need of changing the readme all the time.
