### PR TITLE
unix: optimise UDP buffer allocation

### DIFF
--- a/src/unix/udp.c
+++ b/src/unix/udp.c
@@ -243,7 +243,7 @@ static void uv__udp_recvmsg(uv_loop_t* loop,
       else
         handle->recv_cb(handle, -errno, &buf, NULL, 0);
     }
-    else {
+    else if (next_size > 0) {
       flags = 0;
 
       if (h.msg_flags & MSG_TRUNC)

--- a/src/unix/udp.c
+++ b/src/unix/udp.c
@@ -206,6 +206,9 @@ static void uv__udp_recvmsg(uv_loop_t* loop,
        * without reading it, and avoid allocating a buffer.
        */
 
+      buf.base = NULL;
+      buf.len = 0;
+
       /* Attempt to read the packet. */
       do {
         nread = read(handle->io_watcher.fd, &fake_buffer, 1);


### PR DESCRIPTION
Instead of always allocating a 64KB buffer, use FIONREAD to check the size of the next incoming packet.

I intended to use FIONREAD here to check if any packet is pending, and avoid allocating a buffer (simply returning instead) if no packet is pending.  However, this isn't possible with FIONREAD: if a zero-byte packet is pending, we would spin forever as the socket will appear readable but we'll never read the packet.

Still, this is a minor worthwhile optimisation.
