### PR TITLE
tcp: reveal bind-time errors before listen

### DIFF
--- a/src/win/tcp.c
+++ b/src/win/tcp.c
@@ -1171,6 +1171,12 @@ int uv_tcp_duplicate_socket(uv_tcp_t* handle, int pid,
       if (!(handle->flags & UV_HANDLE_BOUND)) {
         return ERROR_INVALID_PARAMETER;
       }
+
+      /* Report any deferred bind errors now. */
+      if (handle->flags & UV_HANDLE_BIND_ERROR) {
+        return handle->bind_error;
+      }
+
       if (listen(handle->socket, SOMAXCONN) == SOCKET_ERROR) {
         return WSAGetLastError();
       }


### PR DESCRIPTION
Changed uv_tcp_duplicate_socket to reveal any bind-time errors
before calling listen().

This fix is 100% windows specific.

It helps fix Node.js unite test test-cluster-bind-twice on Windows.
