### PR TITLE
Getaddrinfo fail timeout

### DIFF
--- a/test/run-benchmarks.c
+++ b/test/run-benchmarks.c
@@ -29,9 +29,6 @@
 #include "benchmark-list.h"
 
 
-/* The time in milliseconds after which a single benchmark times out. */
-#define BENCHMARK_TIMEOUT  60000
-
 static int maybe_run_test(int argc, char **argv);
 
 
@@ -39,7 +36,7 @@ int main(int argc, char **argv) {
   platform_init(argc, argv);
 
   switch (argc) {
-  case 1: return run_tests(BENCHMARK_TIMEOUT, 1);
+  case 1: return run_tests(1);
   case 2: return maybe_run_test(argc, argv);
   case 3: return run_test_part(argv[1], argv[2]);
   default:
@@ -60,5 +57,5 @@ static int maybe_run_test(int argc, char **argv) {
     return 42;
   }
 
-  return run_test(argv[1], BENCHMARK_TIMEOUT, 1, 1);
+  return run_test(argv[1], 1, 1);
 }

--- a/test/run-tests.c
+++ b/test/run-tests.c
@@ -36,9 +36,6 @@
 /* Actual tests and helpers are defined in test-list.h */
 #include "test-list.h"
 
-/* The time in milliseconds after which a single test times out. */
-#define TEST_TIMEOUT  5000
-
 int ipc_helper(int listen_after_write);
 int ipc_helper_tcp_connection(void);
 int ipc_send_recv_helper(void);
@@ -53,7 +50,7 @@ int main(int argc, char **argv) {
   argv = uv_setup_args(argc, argv);
 
   switch (argc) {
-  case 1: return run_tests(TEST_TIMEOUT, 0);
+  case 1: return run_tests(0);
   case 2: return maybe_run_test(argc, argv);
   case 3: return run_test_part(argv[1], argv[2]);
   default:
@@ -155,5 +152,5 @@ static int maybe_run_test(int argc, char **argv) {
     return 1;
   }
 
-  return run_test(argv[1], TEST_TIMEOUT, 0, 1);
+  return run_test(argv[1], 0, 1);
 }

--- a/test/runner.c
+++ b/test/runner.c
@@ -90,7 +90,7 @@ const char* fmt(double d) {
 }
 
 
-int run_tests(int timeout, int benchmark_output) {
+int run_tests(int benchmark_output) {
   int total;
   int passed;
   int failed;
@@ -130,7 +130,7 @@ int run_tests(int timeout, int benchmark_output) {
       log_progress(total, passed, failed, todos, skipped, task->task_name);
     }
 
-    test_result = run_test(task->task_name, timeout, benchmark_output, current);
+    test_result = run_test(task->task_name, benchmark_output, current);
     switch (test_result) {
     case TEST_OK: passed++; break;
     case TEST_TODO: todos++; break;
@@ -189,7 +189,6 @@ void log_tap_result(int test_count,
 
 
 int run_test(const char* test,
-             int timeout,
              int benchmark_output,
              int test_count) {
   char errmsg[1024] = "no error";
@@ -279,7 +278,7 @@ int run_test(const char* test,
     goto out;
   }
 
-  result = process_wait(main_proc, 1, timeout);
+  result = process_wait(main_proc, 1, task->timeout);
   if (result == -1) {
     FATAL("process_wait failed");
   } else if (result == -2) {

--- a/test/runner.h
+++ b/test/runner.h
@@ -41,6 +41,9 @@ typedef struct {
   int (*main)(void);
   int is_helper;
   int show_output;
+
+  /* The time in milliseconds after which a single test times out. */
+  int timeout;
 } task_entry_t, bench_entry_t;
 
 
@@ -58,10 +61,10 @@ typedef struct {
   int run_test_##name(void);
 
 #define TEST_ENTRY(name)                            \
-    { #name, #name, &run_test_##name, 0, 0 },
+    { #name, #name, &run_test_##name, 0, 0, 5000 },
 
-#define TEST_OUTPUT_ENTRY(name)                     \
-    { #name, #name, &run_test_##name, 0, 1 },
+#define TEST_ENTRY_CUSTOM(name, is_helper, show_output, timeout) \
+    { #name, #name, &run_test_##name, is_helper, show_output, timeout },
 
 #define BENCHMARK_DECLARE(name)                     \
   int run_benchmark_##name(void);
@@ -97,13 +100,12 @@ extern task_entry_t TASKS[];
 /*
  * Run all tests.
  */
-int run_tests(int timeout, int benchmark_output);
+int run_tests(int benchmark_output);
 
 /*
  * Run a single test. Starts up any helpers.
  */
 int run_test(const char* test,
-             int timeout,
              int benchmark_output,
              int test_count);
 

--- a/test/runner.h
+++ b/test/runner.h
@@ -42,7 +42,9 @@ typedef struct {
   int is_helper;
   int show_output;
 
-  /* The time in milliseconds after which a single test times out. */
+  /*
+   * The time in milliseconds after which a single test or benchmark times out.
+   */
   int timeout;
 } task_entry_t, bench_entry_t;
 
@@ -70,7 +72,7 @@ typedef struct {
   int run_benchmark_##name(void);
 
 #define BENCHMARK_ENTRY(name)                       \
-    { #name, #name, &run_benchmark_##name, 0, 0 },
+    { #name, #name, &run_benchmark_##name, 0, 0, 60000 },
 
 #define HELPER_DECLARE(name)                        \
   int run_helper_##name(void);

--- a/test/test-list.h
+++ b/test/test-list.h
@@ -248,7 +248,7 @@ HELPER_DECLARE (pipe_echo_server)
 
 
 TASK_LIST_START
-  TEST_OUTPUT_ENTRY  (platform_output)
+  TEST_ENTRY_CUSTOM (platform_output,0,1,5000)
 
 #if 0
   TEST_ENTRY  (callback_order)

--- a/test/test-list.h
+++ b/test/test-list.h
@@ -248,7 +248,7 @@ HELPER_DECLARE (pipe_echo_server)
 
 
 TASK_LIST_START
-  TEST_ENTRY_CUSTOM (platform_output,0,1,5000)
+  TEST_ENTRY_CUSTOM (platform_output, 0, 1, 5000)
 
 #if 0
   TEST_ENTRY  (callback_order)
@@ -432,7 +432,7 @@ TASK_LIST_START
 
   TEST_ENTRY  (hrtime)
 
-  TEST_ENTRY_CUSTOM (getaddrinfo_fail,0,0,10000)
+  TEST_ENTRY_CUSTOM (getaddrinfo_fail, 0, 0, 10000)
 
   TEST_ENTRY  (getaddrinfo_basic)
   TEST_ENTRY  (getaddrinfo_concurrent)

--- a/test/test-list.h
+++ b/test/test-list.h
@@ -432,7 +432,8 @@ TASK_LIST_START
 
   TEST_ENTRY  (hrtime)
 
-  TEST_ENTRY  (getaddrinfo_fail)
+  TEST_ENTRY_CUSTOM (getaddrinfo_fail,0,0,10000)
+
   TEST_ENTRY  (getaddrinfo_basic)
   TEST_ENTRY  (getaddrinfo_concurrent)
 


### PR DESCRIPTION
On my machine `getaddrinfo_fail` consistently times out:

<pre>
=============================================================
&#91;%  61|+ 125|-   0|T   0|S   0]: getaddrinfo_fail
`getaddrinfo_fail` failed: timeout
Output from process `getaddrinfo_fail`: (no output)
=============================================================
&#91;% 100|+ 203|-   1|T   0|S   0]: Done.
FAIL: test/run-tests
</pre>


Tracing through the call stack showed that `getaddrinfo` was taking just a bit longer than the 5 second timeout to give up on the fake hostname:

<pre>
$ test/run-tests getaddrinfo_fail getaddrinfo_fail
getaddrinfo_fail start:     1391183554.344
uv_getaddrinfo start:       1391183554.344
uv_getaddrinfo end:         1391183554.344
uv__getaddrinfo_work start: 1391183554.344
<b>getaddrinfo start:          1391183554.344</b>
uv__io_poll start:          1391183554.344
uv__epoll_wait start:       1391183554.344
<b>getaddrinfo end:            1391183559.457</b>
uv__getaddrinfo_work end:   1391183559.457
uv__epoll_wait end:         1391183559.457
uv__async_io start:         1391183559.457
uv__async_event start:      1391183559.457
uv__work_done start:        1391183559.457
uv__getaddrinfo_done start: 1391183559.457
uv__getaddrinfo_done end:   1391183559.457
getaddrinfo_fail_cb start:  1391183559.457
getaddrinfo_fail_cb end:    1391183559.457
uv__work_done end:          1391183559.457
uv__async_event end:        1391183559.457
getaddrinfo_fail end:       1391183559.457
</pre>


In this patch I've upped the timeout to 10000 to compensate.  I've also modified the test harness to support setting timeouts on a per-test basis (e.g. _only_ getaddrinfo_fail has a 10000 timeout, the other tests remain at the default).

I worked my way through the contribution guidelines, so hopefully everything is in order.  Let me know if there's anything I missed.

Thank you!
