### PR TITLE
unix: call setgoups before calling setuid/setgid

### DIFF
--- a/src/unix/process.c
+++ b/src/unix/process.c
@@ -330,6 +330,20 @@ static void uv__process_child_init(const uv_process_options_t* options,
     _exit(127);
   }
 
+  if (options->flags & (UV_PROCESS_SETUID | UV_PROCESS_SETGID)) {
+    /* When dropping privileges from root, the `setgroups` call will
+     * remove any extraneous groups. If we don't call this, then
+     * even though our uid has dropped, we may still have groups
+     * that enable us to do super-user things. This will fail if we
+     * aren't root, so don't bother checking the return value, this
+     * is just done as an optimistic privilege dropping function.
+     */
+    int saved_errno;
+    saved_errno = errno;
+    setgroups(0, NULL);
+    errno = saved_errno;
+  }
+
   if ((options->flags & UV_PROCESS_SETGID) && setgid(options->gid)) {
     uv__write_int(error_fd, -errno);
     perror("setgid()");


### PR DESCRIPTION
Partial fix for #1093

Shamelessly taken from: https://github.com/mozilla/rust/pull/12085

/cc @indutny

If you have a few milliseconds to spare, it'd be great to get your input, @bnoordhuis.

As for the dropping caps part, I'll need to look into that, doesn't look anywhere straightforward :-/
