### PR TITLE
unix: Fail gracefully when calling uv_shutdown twice

### DIFF
--- a/src/unix/stream.c
+++ b/src/unix/stream.c
@@ -1109,7 +1109,8 @@ int uv_shutdown(uv_shutdown_t* req, uv_stream_t* stream, uv_shutdown_cb cb) {
   if (!(stream->flags & UV_STREAM_WRITABLE) ||
       stream->flags & UV_STREAM_SHUT ||
       stream->flags & UV_CLOSED ||
-      stream->flags & UV_CLOSING) {
+      stream->flags & UV_CLOSING ||
+      stream->flags & UV_STREAM_SHUTTING) {
     return -ENOTCONN;
   }
 

--- a/test/test-list.h
+++ b/test/test-list.h
@@ -99,6 +99,7 @@ TEST_DECLARE   (connection_fail_doesnt_auto_close)
 TEST_DECLARE   (shutdown_close_tcp)
 TEST_DECLARE   (shutdown_close_pipe)
 TEST_DECLARE   (shutdown_eof)
+TEST_DECLARE   (shutdown_twice)
 TEST_DECLARE   (callback_stack)
 TEST_DECLARE   (error_message)
 TEST_DECLARE   (timer)
@@ -362,6 +363,9 @@ TASK_LIST_START
 
   TEST_ENTRY  (shutdown_eof)
   TEST_HELPER (shutdown_eof, tcp4_echo_server)
+
+  TEST_ENTRY  (shutdown_twice)
+  TEST_HELPER (shutdown_twice, tcp4_echo_server)
 
   TEST_ENTRY  (callback_stack)
   TEST_HELPER (callback_stack, tcp4_echo_server)

--- a/test/test-shutdown-twice.c
+++ b/test/test-shutdown-twice.c
@@ -1,0 +1,85 @@
+/* Copyright Joyent, Inc. and other Node contributors. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to
+ * deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+
+/*
+ * This is a regression test for issue #1113 (calling uv_shutdown twice will 
+ * leave a ghost request in the system)
+ */
+
+#include "uv.h"
+#include "task.h"
+
+static uv_shutdown_t req1;
+static uv_shutdown_t req2;
+
+static int shutdown_cb_called = 0;
+
+static void close_cb(uv_handle_t* handle) {
+
+}
+
+static void shutdown_cb(uv_shutdown_t* req, int status) {
+  ASSERT(req == &req1);
+  ASSERT(status == 0);
+  shutdown_cb_called++;
+  uv_close((uv_handle_t*) req->handle, close_cb);
+}
+
+static void connect_cb(uv_connect_t* req, int status) {
+  int r;
+
+  ASSERT(status == 0);
+
+  r = uv_shutdown(&req1, req->handle, shutdown_cb);
+  ASSERT(r == 0);
+  r = uv_shutdown(&req2, req->handle, shutdown_cb);
+  ASSERT(r != 0);
+
+}
+
+TEST_IMPL(shutdown_twice) {
+  struct sockaddr_in addr;
+  uv_loop_t* loop;
+  int r;
+  uv_tcp_t h;
+
+  uv_connect_t connect_req;
+
+  ASSERT(0 == uv_ip4_addr("127.0.0.1", TEST_PORT, &addr));
+  loop = uv_default_loop();
+
+  r = uv_tcp_init(loop, &h);
+
+  r = uv_tcp_connect(&connect_req,
+                     &h,
+                     (const struct sockaddr*) &addr,
+                     connect_cb);
+  printf("%d\n", r);
+  ASSERT(r == 0); 
+
+  r = uv_run(uv_default_loop(), UV_RUN_DEFAULT);
+  ASSERT(r == 0);
+
+  ASSERT(shutdown_cb_called == 1);
+
+  MAKE_VALGRIND_HAPPY();
+  return 0;
+}

--- a/uv.gyp
+++ b/uv.gyp
@@ -345,6 +345,7 @@
         'test/test-semaphore.c',
         'test/test-shutdown-close.c',
         'test/test-shutdown-eof.c',
+        'test/test-shutdown-twice.c',
         'test/test-signal.c',
         'test/test-signal-multiple-loops.c',
         'test/test-spawn.c',


### PR DESCRIPTION
Before this, one of the requests was left as a ghost in the system. See https://github.com/JuliaLang/julia/issues/5793
