### PR TITLE
tcp: freeze in uv_tcp_endgame

### DIFF
--- a/src/win/tcp.c
+++ b/src/win/tcp.c
@@ -579,6 +579,7 @@ int uv_tcp_listen(uv_tcp_t* handle, int backlog, uv_connection_cb cb) {
       req->accept_socket = INVALID_SOCKET;
       req->data = handle;
       req->wait_handle = INVALID_HANDLE_VALUE;
+      req->event_handle = NULL;
     }
   }
 
@@ -992,9 +993,11 @@ void uv_process_tcp_write_req(uv_loop_t* loop, uv_tcp_t* handle,
   if (handle->flags & UV_HANDLE_EMULATE_IOCP) {
     if (req->wait_handle != INVALID_HANDLE_VALUE) {
       UnregisterWait(req->wait_handle);
+      req->wait_handle = INVALID_HANDLE_VALUE;
     }
     if (req->event_handle) {
       CloseHandle(req->event_handle);
+      req->event_handle = NULL;
     }
   }
 


### PR DESCRIPTION
The event_handle field of unused accept requests was not being
initialized properly. As a result, uv_tcp_endgame would try to close
an invalid handle and this could lead to unexpected behavior.

This fixes node.js test test-cluster-disconnect.js on Windows.
