### PR TITLE
unix: Fix a critical regression in the timer code

### DIFF
--- a/src/heap-inl.h
+++ b/src/heap-inl.h
@@ -219,9 +219,9 @@ HEAP_EXPORT(void heap_remove(struct heap* heap,
    */
   for (;;) {
     smallest = child;
-    if (child->left != NULL && less_than(smallest, child))
+    if (child->left != NULL && less_than(child->left, smallest))
       smallest = child->left;
-    if (child->right != NULL && less_than(smallest, child))
+    if (child->right != NULL && less_than(child->right, smallest))
       smallest = child->right;
     if (smallest == child)
       break;


### PR DESCRIPTION
This was pretty obviously wrong. This issue is an extremely serious bug that never should have made it through code review.
