### PR TITLE
windows: fix warnings of MinGW -Wall -O3

### DIFF
--- a/src/win/core.c
+++ b/src/win/core.c
@@ -70,11 +70,13 @@ static int uv__crt_dbg_report_handler(int report_type, char *message, int *ret_v
 #endif
 
 
+#if !defined(__MINGW32__) || __MSVCRT_VERSION__ >= 0x800
 static void uv__crt_invalid_parameter_handler(const wchar_t* expression,
     const wchar_t* function, const wchar_t * file, unsigned int line,
     uintptr_t reserved) {
   /* No-op. */
 }
+#endif
 
 
 static void uv_init(void) {
@@ -192,7 +194,7 @@ int uv_loop_close(uv_loop_t* loop) {
       return UV_EBUSY;
   }
   if (loop != &uv_default_loop_) {
-    int i;
+    size_t i;
     for (i = 0; i < ARRAY_SIZE(loop->poll_peer_sockets); i++) {
       SOCKET sock = loop->poll_peer_sockets[i];
       if (sock != 0 && sock != INVALID_SOCKET)

--- a/src/win/fs.c
+++ b/src/win/fs.c
@@ -97,8 +97,10 @@
 
 #define TIME_T_TO_FILETIME(time, filetime_ptr)                              \
   do {                                                                      \
-    *(uint64_t*) (filetime_ptr) = ((int64_t) (time) * 10000000LL) +         \
+    uint64_t bigtime = ((int64_t) (time) * 10000000LL) +                    \
                                   116444736000000000ULL;                    \
+    (filetime_ptr)->dwLowDateTime = bigtime & 0xFFFFFFFF;                   \
+    (filetime_ptr)->dwHighDateTime = bigtime >> 32;                         \
   } while(0)
 
 #define IS_SLASH(c) ((c) == L'\\' || (c) == L'/')
@@ -121,7 +123,7 @@ INLINE static int fs__capture_path(uv_loop_t* loop, uv_fs_t* req,
     const char* path, const char* new_path, const int copy_path) {
   char* buf;
   char* pos;
-  ssize_t buf_sz = 0, path_len, pathw_len, new_pathw_len;
+  ssize_t buf_sz = 0, path_len, pathw_len = 0, new_pathw_len = 0;
 
   /* new_path can only be set if path is also set. */
   assert(new_path == NULL || path != NULL);
@@ -181,7 +183,7 @@ INLINE static int fs__capture_path(uv_loop_t* loop, uv_fs_t* req,
                                   -1,
                                   (WCHAR*) pos,
                                   pathw_len);
-    assert(r == pathw_len);
+    assert(r == (DWORD) pathw_len);
     req->pathw = (WCHAR*) pos;
     pos += r * sizeof(WCHAR);
   } else {
@@ -195,7 +197,7 @@ INLINE static int fs__capture_path(uv_loop_t* loop, uv_fs_t* req,
                                   -1,
                                   (WCHAR*) pos,
                                   new_pathw_len);
-    assert(r == new_pathw_len);
+    assert(r == (DWORD) new_pathw_len);
     req->new_pathw = (WCHAR*) pos;
     pos += r * sizeof(WCHAR);
   } else {

--- a/src/win/internal.h
+++ b/src/win/internal.h
@@ -323,7 +323,7 @@ void uv__fs_poll_endgame(uv_loop_t* loop, uv_fs_poll_t* handle);
 void uv__util_init();
 
 int uv_parent_pid();
-void uv_fatal_error(const int errorno, const char* syscall);
+__declspec(noreturn) void uv_fatal_error(const int errorno, const char* syscall);
 
 
 /*

--- a/src/win/pipe.c
+++ b/src/win/pipe.c
@@ -1077,7 +1077,7 @@ static int uv_pipe_write_impl(uv_loop_t* loop,
   int err;
   int result;
   uv_tcp_t* tcp_send_handle;
-  uv_write_t* ipc_header_req;
+  uv_write_t* ipc_header_req = NULL;
   uv_ipc_frame_uv_stream ipc_frame;
 
   if (nbufs != 1 && (nbufs != 0 || !send_handle)) {
@@ -1256,6 +1256,7 @@ static int uv_pipe_write_impl(uv_loop_t* loop,
       /* Request completed immediately. */
       req->queued_bytes = 0;
     } else {
+      assert(ipc_header_req != NULL);
       /* Request queued by the kernel. */
       if (WaitForSingleObject(ipc_header_req->overlapped.hEvent, INFINITE) !=
           WAIT_OBJECT_0) {

--- a/src/win/poll.c
+++ b/src/win/poll.c
@@ -85,6 +85,7 @@ static void uv__fast_poll_submit_poll_req(uv_loop_t* loop, uv_poll_t* handle) {
     handle->mask_events_2 = 0;
   } else {
     assert(0);
+    return;
   }
 
   /* Setting Exclusive to TRUE makes the other poll request return if there */
@@ -119,7 +120,7 @@ static void uv__fast_poll_submit_poll_req(uv_loop_t* loop, uv_poll_t* handle) {
 
 static int uv__fast_poll_cancel_poll_req(uv_loop_t* loop, uv_poll_t* handle) {
   AFD_POLL_INFO afd_poll_info;
-  DWORD result;
+  int result;
 
   afd_poll_info.Exclusive = TRUE;
   afd_poll_info.NumberOfHandles = 1;
@@ -158,6 +159,7 @@ static void uv__fast_poll_process_poll_req(uv_loop_t* loop, uv_poll_t* handle,
     mask_events = handle->mask_events_2;
   } else {
     assert(0);
+    return;
   }
 
   /* Report an error unless the select was just interrupted. */
@@ -281,7 +283,7 @@ static SOCKET uv__fast_poll_get_peer_socket(uv_loop_t* loop,
   SOCKET peer_socket;
 
   index = -1;
-  for (i = 0; i < ARRAY_SIZE(uv_msafd_provider_ids); i++) {
+  for (i = 0; (size_t) i < ARRAY_SIZE(uv_msafd_provider_ids); i++) {
     if (memcmp((void*) &protocol_info->ProviderId,
                (void*) &uv_msafd_provider_ids[i],
                sizeof protocol_info->ProviderId) == 0) {
@@ -392,6 +394,7 @@ static void uv__slow_poll_submit_poll_req(uv_loop_t* loop, uv_poll_t* handle) {
     handle->mask_events_2 = 0;
   } else {
     assert(0);
+    return;
   }
 
   if (!QueueUserWorkItem(uv__slow_poll_thread_proc,
@@ -418,6 +421,7 @@ static void uv__slow_poll_process_poll_req(uv_loop_t* loop, uv_poll_t* handle,
     mask_events = handle->mask_events_2;
   } else {
     assert(0);
+    return;
   }
 
   if (!REQ_SUCCESS(req)) {

--- a/src/win/process-stdio.c
+++ b/src/win/process-stdio.c
@@ -327,7 +327,7 @@ int uv__stdio_create(uv_loop_t* loop,
         /* an uv_pipe_t for use by the parent. The other one is given to */
         /* the child. */
         uv_pipe_t* parent_pipe = (uv_pipe_t*) fdopt.data.stream;
-        HANDLE child_pipe;
+        HANDLE child_pipe = INVALID_HANDLE_VALUE;
 
         /* Create a new, connected pipe pair. stdio[i].stream should point */
         /* to an uninitialized, but not connected pipe handle. */
@@ -389,6 +389,7 @@ int uv__stdio_create(uv_loop_t* loop,
 
           default:
             assert(0);
+            return -1;
         }
 
         CHILD_STDIO_HANDLE(buffer, i) = child_handle;
@@ -423,11 +424,9 @@ int uv__stdio_create(uv_loop_t* loop,
         }
 
         /* Make an inheritable copy of the handle. */
-        if (uv__duplicate_handle(loop,
-                             stream_handle,
-                             &child_handle) < 0) {
+        err = uv__duplicate_handle(loop, stream_handle, &child_handle);
+        if (err)
           goto error;
-        }
 
         CHILD_STDIO_HANDLE(buffer, i) = child_handle;
         CHILD_STDIO_CRT_FLAGS(buffer, i) = crt_flags;
@@ -436,6 +435,7 @@ int uv__stdio_create(uv_loop_t* loop,
 
       default:
         assert(0);
+        return -1;
     }
   }
 

--- a/src/win/process.c
+++ b/src/win/process.c
@@ -624,7 +624,7 @@ int make_program_env(char* env_block[], WCHAR** dst_ptr) {
   char** env;
   size_t env_len = 1; /* room for closing null */
   int len;
-  int i;
+  size_t i;
   DWORD var_size;
 
   env_var_t required_vars[] = {

--- a/src/win/tty.c
+++ b/src/win/tty.c
@@ -698,7 +698,7 @@ void uv_process_tty_read_raw_req(uv_loop_t* loop, uv_tty_t* handle,
         buf.base[buf_used++] = handle->last_key[handle->last_key_offset++];
 
         /* If the buffer is full, emit it */
-        if (buf_used == buf.len) {
+        if ((size_t) buf_used == buf.len) {
           handle->read_cb((uv_stream_t*) handle, buf_used, &buf);
           buf = uv_null_buf_;
           buf_used = 0;

--- a/src/win/util.c
+++ b/src/win/util.c
@@ -340,7 +340,7 @@ int uv_parent_pid() {
   int parent_pid = -1;
   HANDLE handle;
   PROCESSENTRY32 pe;
-  int current_pid = GetCurrentProcessId();
+  DWORD current_pid = GetCurrentProcessId();
 
   pe.dwSize = sizeof(PROCESSENTRY32);
   handle = CreateToolhelp32Snapshot(TH32CS_SNAPPROCESS, 0);
@@ -655,7 +655,7 @@ int uv_cpu_info(uv_cpu_info_t** cpu_infos_ptr, int* cpu_count_ptr) {
     DWORD cpu_speed_size = sizeof(cpu_speed);
     WCHAR cpu_brand[256];
     DWORD cpu_brand_size = sizeof(cpu_brand);
-    int len;
+    size_t len;
 
     len = _snwprintf(key_name,
                      ARRAY_SIZE(key_name),

--- a/src/win/winsock.c
+++ b/src/win/winsock.c
@@ -40,7 +40,8 @@ struct sockaddr_in6 uv_addr_ip6_any_;
  */
 static BOOL uv_get_extension_function(SOCKET socket, GUID guid,
     void **target) {
-  DWORD result, bytes;
+  int result;
+  DWORD bytes;
 
   result = WSAIoctl(socket,
                     SIO_GET_EXTENSION_FUNCTION_POINTER,


### PR DESCRIPTION
sweep MinGW warnings.

still two warnings remains:

```
src/win/fs.c: In function 'fs__utime_handle':
src/win/fs.c:1187:3: warning: dereferencing type-punned pointer will break stric
t-aliasing rules [-Wstrict-aliasing]
   TIME_T_TO_FILETIME((time_t) atime, &filetime_a);
   ^
src/win/fs.c:1188:3: warning: dereferencing type-punned pointer will break stric
t-aliasing rules [-Wstrict-aliasing]
   TIME_T_TO_FILETIME((time_t) mtime, &filetime_m);
   ^
```

warnings fixed:
- unsigned/signed unmatched, use int i to iteration array with ARRAY_SIZE(...) -- which is unsigned
- uv__crt_invalid_parameter_handler not used on MinGW
- several uninitialized warning for several places. but some are caused by assert(0); and abort(); (but MinGW doesn't know it will abort)
- some Windows API returns int, not DWORD.
- InterlockedExchange's first argument is volatile LONG_, not unsigned long_.
