### PR TITLE
unix, windows: set required size on UV_ENOBUFS

### DIFF
--- a/include/uv.h
+++ b/include/uv.h
@@ -1203,9 +1203,12 @@ UV_EXTERN void uv_pipe_connect(uv_connect_t* req,
  *
  * A preallocated buffer must be provided. The len parameter holds the
  * length of the buffer and it's set to the number of bytes written to the
- * buffer on output.
+ * buffer on output. If the buffer is not big enough UV_ENOBUFS will be
+ * returned and len will contain the required size.
  */
-UV_EXTERN int uv_pipe_getsockname(const uv_pipe_t* handle, char* buf, size_t* len);
+UV_EXTERN int uv_pipe_getsockname(const uv_pipe_t* handle,
+                                  char* buf,
+                                  size_t* len);
 
 /*
  * This setting applies to Windows only.
@@ -1934,9 +1937,11 @@ UV_EXTERN int uv_fs_poll_start(uv_fs_poll_t* handle,
 UV_EXTERN int uv_fs_poll_stop(uv_fs_poll_t* handle);
 
 /*
- * Get the path befing monitored by the handle. The buffer must be preallocated
+ * Get the path being monitored by the handle. The buffer must be preallocated
  * by the user. Returns 0 on success or an error code < 0 in case of failure.
- * On sucess, `buf` will contain the path and `len` its length.
+ * On sucess, `buf` will contain the path and `len` its length. If the buffer
+ * is not big enough UV_ENOBUFS will be returned and len will be set to the
+ * required size.
  */
 UV_EXTERN int uv_fs_poll_getpath(uv_fs_poll_t* handle, char* buf, size_t* len);
 
@@ -2044,9 +2049,11 @@ UV_EXTERN int uv_fs_event_start(uv_fs_event_t* handle,
 UV_EXTERN int uv_fs_event_stop(uv_fs_event_t* handle);
 
 /*
- * Get the path befing monitored by the handle. The buffer must be preallocated
+ * Get the path being monitored by the handle. The buffer must be preallocated
  * by the user. Returns 0 on success or an error code < 0 in case of failure.
- * On sucess, `buf` will contain the path and `len` its length.
+ * On sucess, `buf` will contain the path and `len` its length. If the buffer
+ * is not big enough UV_ENOBUFS will be returned and len will be set to the
+ * required size.
  */
 UV_EXTERN int uv_fs_event_getpath(uv_fs_event_t* handle,
                                   char* buf,

--- a/src/fs-poll.c
+++ b/src/fs-poll.c
@@ -132,7 +132,7 @@ int uv_fs_poll_getpath(uv_fs_poll_t* handle, char* buf, size_t* len) {
 
   required_len = strlen(ctx->path) + 1;
   if (required_len > *len) {
-    *len = 0;
+    *len = required_len;
     return UV_ENOBUFS;
   }
 

--- a/src/unix/pipe.c
+++ b/src/unix/pipe.c
@@ -233,7 +233,7 @@ int uv_pipe_getsockname(const uv_pipe_t* handle, char* buf, size_t* len) {
 
 
   if (addrlen > *len) {
-    *len = 0;
+    *len = addrlen;
     return UV_ENOBUFS;
   }
 

--- a/src/uv-common.c
+++ b/src/uv-common.c
@@ -455,7 +455,7 @@ int uv_fs_event_getpath(uv_fs_event_t* handle, char* buf, size_t* len) {
 
   required_len = strlen(handle->path) + 1;
   if (required_len > *len) {
-    *len = 0;
+    *len = required_len;
     return UV_ENOBUFS;
   }
 


### PR DESCRIPTION
When the supplied buffer is not big enough and UV_ENOBUFS is
returned, hint the user about the required size by setting
the len paramemeter to the required value.

Applies to:
- uv_pipe_getsockname
- uv_fs_event_getpath
- uv_fs_poll_getpath
