### PR TITLE
unix, windows: clarify what uv_stream_set_blocking does

### DIFF
--- a/include/uv.h
+++ b/include/uv.h
@@ -749,11 +749,7 @@ UV_EXTERN int uv_is_writable(const uv_stream_t* handle);
  * Relying too much on this API is not recommended. It is likely to change
  * significantly in the future.
  *
- * On windows this currently works only for uv_pipe_t instances. On unix it
- * works for tcp, pipe and tty instances. Be aware that changing the blocking
- * mode on unix sets or clears the O_NONBLOCK bit. If you are sharing a handle
- * with another process, the other process is affected by the change too,
- * which can lead to unexpected results.
+ * Currently this only works on Windows and only for uv_pipe_t handles.
  *
  * Also libuv currently makes no ordering guarantee when the blocking mode
  * is changed after write requests have already been submitted. Therefore it is

--- a/src/unix/stream.c
+++ b/src/unix/stream.c
@@ -1511,7 +1511,5 @@ void uv__stream_close(uv_stream_t* handle) {
 
 
 int uv_stream_set_blocking(uv_stream_t* handle, int blocking) {
-  assert(0 && "implement me");
-  abort();
-  return 0;
+  return UV_ENOSYS;
 }

--- a/src/win/stream.c
+++ b/src/win/stream.c
@@ -244,6 +244,9 @@ int uv_is_writable(const uv_stream_t* handle) {
 
 
 int uv_stream_set_blocking(uv_stream_t* handle, int blocking) {
+  if (stream->type != UV_NAMED_PIPE)
+    return UV_EINVAL;
+
   if (blocking != 0)
     handle->flags |= UV_HANDLE_BLOCKING_WRITES;
   else


### PR DESCRIPTION
Also replace the assert with an error on unix.
