### PR TITLE
process: fix bug that mistakenly closes child stdin in some cases

### DIFF
--- a/src/unix/process.c
+++ b/src/unix/process.c
@@ -309,6 +309,11 @@ static void uv__process_child_init(const uv_process_options_t* options,
       }
     }
 
+    if (close_fd != -1) {
+      /* Can't call uv__close, since that might fail an assertion if close_fd=0 */
+      close(close_fd);
+    }
+
     if (fd == use_fd)
       uv__cloexec(use_fd, 0);
     else
@@ -316,9 +321,6 @@ static void uv__process_child_init(const uv_process_options_t* options,
 
     if (fd <= 2)
       uv__nonblock(fd, 0);
-
-    if (close_fd != -1)
-      uv__close(close_fd);
   }
 
   for (fd = 0; fd < stdio_count; fd++) {

--- a/test/run-tests.c
+++ b/test/run-tests.c
@@ -161,6 +161,14 @@ static int maybe_run_test(int argc, char **argv) {
 
     return 1;
   }
+
+  if (strcmp(argv[1], "spawn_helper9") == 0) {
+    struct stat statbuf;
+    int rc;
+    rc = fstat(0, &statbuf);
+    ASSERT (rc >= 0);
+    return 1;
+  }
 #endif  /* !_WIN32 */
 
   return run_test(argv[1], 0, 1);

--- a/test/test-list.h
+++ b/test/test-list.h
@@ -247,6 +247,7 @@ TEST_DECLARE   (we_get_signal)
 TEST_DECLARE   (we_get_signals)
 TEST_DECLARE   (signal_multiple_loops)
 TEST_DECLARE   (closed_fd_events)
+TEST_DECLARE   (closed_stdin_then_spawn)
 #endif
 #ifdef __APPLE__
 TEST_DECLARE   (osx_select)
@@ -496,6 +497,7 @@ TASK_LIST_START
   TEST_ENTRY  (we_get_signals)
   TEST_ENTRY  (signal_multiple_loops)
   TEST_ENTRY  (closed_fd_events)
+  TEST_ENTRY  (closed_stdin_then_spawn)
 #endif
 
 #ifdef __APPLE__


### PR DESCRIPTION
If a parent process closes 0, and then calls spawn, the following will
happen:
- the first call to socketpair() will return a pair like [0,14]
  in the parent. The kernel allocates fd=0 since it's the lowest
  free file descriptor.
- the child, after fork, in uv__process_child_init,
  calls dup2(use_fd=14,fd=0), which is fine.
- the child then calls close(close_fd=0), which is wrong.

This problem is easily solved by closing the close_fd first, and then
calling dup2 as before.
