### PR TITLE
build: add required libraries to libuv.pc.in

### DIFF
--- a/libuv.pc.in
+++ b/libuv.pc.in
@@ -7,5 +7,5 @@ Name: @PACKAGE_NAME@
 Version: @PACKAGE_VERSION@
 Description: multi-platform support library with a focus on asynchronous I/O.
 
-Libs: -L${libdir} -luv
+Libs: -L${libdir} -luv @LIBS@
 Cflags: -I${includedir}


### PR DESCRIPTION
Example file after patch:

```
$ cat libuv.pc
prefix=/usr/local
exec_prefix=/usr/local
libdir=${exec_prefix}/lib
includedir=${prefix}/include

Name: libuv
Version: 0.11.22
Description: multi-platform support library with a focus on asynchronous I/O.

Libs: -L${libdir} -luv -lrt -lpthread -lnsl -ldl 
Cflags: -I${includedir}
(pkg_config)saghul@alpha:~/src/libuv
```

Note the "Libs" line.
