### PR TITLE
error: add ENXIO for O_NONBLOCK FIFO open()

### DIFF
--- a/include/uv.h
+++ b/include/uv.h
@@ -134,6 +134,7 @@ extern "C" {
   XX( 61, ENOPROTOOPT, "protocol not available")                              \
   XX( 62, ETXTBSY, "text file is busy")                                       \
   XX( 63, ERANGE, "result too large")                                         \
+  XX( 64, ENXIO, "no such device or address")                                 \
 
 
 #define UV_ERRNO_GEN(val, name, s) UV_##name = val,

--- a/src/unix/error.c
+++ b/src/unix/error.c
@@ -108,6 +108,7 @@ uv_err_code uv_translate_sys_error(int sys_errno) {
     case ENOPROTOOPT: return UV_ENOPROTOOPT;
     case ETXTBSY: return UV_ETXTBSY;
     case ERANGE: return UV_ERANGE;
+    case ENXIO: return UV_ENXIO;
     default: return UV_UNKNOWN;
   }
   UNREACHABLE();


### PR DESCRIPTION
When opening FIFO with `O_NONBLOCK` flag, `ENXIO` could be returned if
the readable side hasn't yet opened this FIFO.
