### PR TITLE
openbsd, osx: fix compilation warning on scandir

### DIFF
--- a/src/unix/fs.c
+++ b/src/unix/fs.c
@@ -271,7 +271,11 @@ static ssize_t uv__fs_read(uv_fs_t* req) {
 }
 
 
+#if defined(__OpenBSD__) || (defined(__APPLE__) && !defined(MAC_OS_X_VERSION_10_8))
+static int uv__fs_readdir_filter(struct dirent* dent) {
+#else
 static int uv__fs_readdir_filter(const struct dirent* dent) {
+#endif
   return strcmp(dent->d_name, ".") != 0 && strcmp(dent->d_name, "..") != 0;
 }
 


### PR DESCRIPTION
The select function takes a const struct on newer OSX versions but it
doesn't on OSX <= 10.7 or OpenBSD.
