### PR TITLE
kqueue: invalidate fd in uv_fs_event_t

### DIFF
--- a/src/unix/kqueue.c
+++ b/src/unix/kqueue.c
@@ -359,10 +359,10 @@ fallback:
 void uv__fs_event_close(uv_fs_event_t* handle) {
 #if defined(__APPLE__)
   if (uv__fsevents_close(handle))
-    uv__io_stop(handle->loop, &handle->event_watcher, UV__POLLIN);
-#else
-  uv__io_stop(handle->loop, &handle->event_watcher, UV__POLLIN);
 #endif /* defined(__APPLE__) */
+  {
+    uv__io_close(handle->loop, &handle->event_watcher);
+  }
 
   uv__handle_stop(handle);
 


### PR DESCRIPTION
Invalidate file descriptor when closing `uv_fs_event_t` handle. Note
that `uv__io_stop` is just removing `fd` from `loop->watchers` and not
actually invalidating all consequent events in a `kevent()` results.

fix joyent/node#1101
