### PR TITLE
build: freebsd link with libelf if dtrace enabled

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -269,6 +269,9 @@ endif
 if HAVE_DTRACE
 BUILT_SOURCES = include/uv-dtrace.h
 CLEANFILES += include/uv-dtrace.h
+if FREEBSD
+libuv_la_LDFLAGS += -lelf
+endif
 endif
 
 if DTRACE_NEEDS_OBJECTS


### PR DESCRIPTION
as it says on the tin -- add `-lelf` if we're compiling on freebsd in autoconf land
