### PR TITLE
unix, windows: removed unused status parameter

### DIFF
--- a/include/uv.h
+++ b/include/uv.h
@@ -405,12 +405,11 @@ typedef void (*uv_shutdown_cb)(uv_shutdown_t* req, int status);
 typedef void (*uv_connection_cb)(uv_stream_t* server, int status);
 typedef void (*uv_close_cb)(uv_handle_t* handle);
 typedef void (*uv_poll_cb)(uv_poll_t* handle, int status, int events);
-typedef void (*uv_timer_cb)(uv_timer_t* handle, int status);
-/* TODO: do these really need a status argument? */
-typedef void (*uv_async_cb)(uv_async_t* handle, int status);
-typedef void (*uv_prepare_cb)(uv_prepare_t* handle, int status);
-typedef void (*uv_check_cb)(uv_check_t* handle, int status);
-typedef void (*uv_idle_cb)(uv_idle_t* handle, int status);
+typedef void (*uv_timer_cb)(uv_timer_t* handle);
+typedef void (*uv_async_cb)(uv_async_t* handle);
+typedef void (*uv_prepare_cb)(uv_prepare_t* handle);
+typedef void (*uv_check_cb)(uv_check_t* handle);
+typedef void (*uv_idle_cb)(uv_idle_t* handle);
 typedef void (*uv_exit_cb)(uv_process_t*, int64_t exit_status, int term_signal);
 typedef void (*uv_walk_cb)(uv_handle_t* handle, void* arg);
 typedef void (*uv_fs_cb)(uv_fs_t* req);

--- a/src/fs-poll.c
+++ b/src/fs-poll.c
@@ -41,7 +41,7 @@ struct poll_ctx {
 
 static int statbuf_eq(const uv_stat_t* a, const uv_stat_t* b);
 static void poll_cb(uv_fs_t* req);
-static void timer_cb(uv_timer_t* timer, int status);
+static void timer_cb(uv_timer_t* timer);
 static void timer_close_cb(uv_handle_t* handle);
 
 static uv_stat_t zero_statbuf;
@@ -148,7 +148,7 @@ void uv__fs_poll_close(uv_fs_poll_t* handle) {
 }
 
 
-static void timer_cb(uv_timer_t* timer, int status) {
+static void timer_cb(uv_timer_t* timer) {
   struct poll_ctx* ctx;
 
   ctx = container_of(timer, struct poll_ctx, timer_handle);

--- a/src/unix/async.c
+++ b/src/unix/async.c
@@ -85,7 +85,7 @@ static void uv__async_event(uv_loop_t* loop,
 
     if (h->async_cb == NULL)
       continue;
-    h->async_cb(h, 0);
+    h->async_cb(h);
   }
 }
 

--- a/src/unix/internal.h
+++ b/src/unix/internal.h
@@ -214,7 +214,7 @@ void uv__work_submit(uv_loop_t* loop,
                      struct uv__work *w,
                      void (*work)(struct uv__work *w),
                      void (*done)(struct uv__work *w, int status));
-void uv__work_done(uv_async_t* handle, int status);
+void uv__work_done(uv_async_t* handle);
 
 /* platform specific */
 uint64_t uv__hrtime(uv_clocktype_t type);

--- a/src/unix/loop-watcher.c
+++ b/src/unix/loop-watcher.c
@@ -50,7 +50,7 @@
     QUEUE* q;                                                                 \
     QUEUE_FOREACH(q, &loop->name##_handles) {                                 \
       h = QUEUE_DATA(q, uv_##name##_t, queue);                                \
-      h->name##_cb(h, 0);                                                     \
+      h->name##_cb(h);                                                        \
     }                                                                         \
   }                                                                           \
                                                                               \

--- a/src/unix/threadpool.c
+++ b/src/unix/threadpool.c
@@ -191,7 +191,7 @@ static int uv__work_cancel(uv_loop_t* loop, uv_req_t* req, struct uv__work* w) {
 }
 
 
-void uv__work_done(uv_async_t* handle, int status) {
+void uv__work_done(uv_async_t* handle) {
   struct uv__work* w;
   uv_loop_t* loop;
   QUEUE* q;

--- a/src/unix/timer.c
+++ b/src/unix/timer.c
@@ -159,7 +159,7 @@ void uv__run_timers(uv_loop_t* loop) {
 
     uv_timer_stop(handle);
     uv_timer_again(handle);
-    handle->timer_cb(handle, 0);
+    handle->timer_cb(handle);
   }
 }
 

--- a/src/win/async.c
+++ b/src/win/async.c
@@ -94,6 +94,6 @@ void uv_process_async_wakeup_req(uv_loop_t* loop, uv_async_t* handle,
   if (handle->flags & UV__HANDLE_CLOSING) {
     uv_want_endgame(loop, (uv_handle_t*)handle);
   } else if (handle->async_cb != NULL) {
-    handle->async_cb(handle, 0);
+    handle->async_cb(handle);
   }
 }

--- a/src/win/loop-watcher.c
+++ b/src/win/loop-watcher.c
@@ -115,7 +115,7 @@ void uv_loop_watcher_endgame(uv_loop_t* loop, uv_handle_t* handle) {
       handle = (loop)->next_##name##_handle;                                  \
       (loop)->next_##name##_handle = handle->name##_next;                     \
                                                                               \
-      handle->name##_cb(handle, 0);                                           \
+      handle->name##_cb(handle);                                              \
     }                                                                         \
   }
 

--- a/src/win/pipe.c
+++ b/src/win/pipe.c
@@ -79,7 +79,7 @@ typedef struct {
 static void eof_timer_init(uv_pipe_t* pipe);
 static void eof_timer_start(uv_pipe_t* pipe);
 static void eof_timer_stop(uv_pipe_t* pipe);
-static void eof_timer_cb(uv_timer_t* timer, int status);
+static void eof_timer_cb(uv_timer_t* timer);
 static void eof_timer_destroy(uv_pipe_t* pipe);
 static void eof_timer_close_cb(uv_handle_t* handle);
 
@@ -1695,11 +1695,10 @@ static void eof_timer_stop(uv_pipe_t* pipe) {
 }
 
 
-static void eof_timer_cb(uv_timer_t* timer, int status) {
+static void eof_timer_cb(uv_timer_t* timer) {
   uv_pipe_t* pipe = (uv_pipe_t*) timer->data;
   uv_loop_t* loop = timer->loop;
 
-  assert(status == 0); /* timers can't fail */
   assert(pipe->type == UV_NAMED_PIPE);
 
   /* This should always be true, since we start the timer only */

--- a/src/win/timer.c
+++ b/src/win/timer.c
@@ -249,6 +249,6 @@ void uv_process_timers(uv_loop_t* loop) {
       uv__handle_stop(timer);
     }
 
-    timer->timer_cb((uv_timer_t*) timer, 0);
+    timer->timer_cb((uv_timer_t*) timer);
   }
 }

--- a/test/benchmark-async-pummel.c
+++ b/test/benchmark-async-pummel.c
@@ -36,7 +36,7 @@ static const char stop[]    = "stop";
 static const char stopped[] = "stopped";
 
 
-static void async_cb(uv_async_t* handle, int status) {
+static void async_cb(uv_async_t* handle) {
   if (++callbacks == NUM_PINGS) {
     /* Tell the pummel thread to stop. */
     ACCESS_ONCE(const char*, handle->data) = stop;

--- a/test/benchmark-async.c
+++ b/test/benchmark-async.c
@@ -40,7 +40,7 @@ struct ctx {
 };
 
 
-static void worker_async_cb(uv_async_t* handle, int status) {
+static void worker_async_cb(uv_async_t* handle) {
   struct ctx* ctx = container_of(handle, struct ctx, worker_async);
 
   ASSERT(0 == uv_async_send(&ctx->main_async));
@@ -52,7 +52,7 @@ static void worker_async_cb(uv_async_t* handle, int status) {
 }
 
 
-static void main_async_cb(uv_async_t* handle, int status) {
+static void main_async_cb(uv_async_t* handle) {
   struct ctx* ctx = container_of(handle, struct ctx, main_async);
 
   ASSERT(0 == uv_async_send(&ctx->worker_async));

--- a/test/benchmark-loop-count.c
+++ b/test/benchmark-loop-count.c
@@ -32,18 +32,18 @@ static uv_idle_t idle_handle;
 static uv_timer_t timer_handle;
 
 
-static void idle_cb(uv_idle_t* handle, int status) {
+static void idle_cb(uv_idle_t* handle) {
   if (++ticks == NUM_TICKS)
     uv_idle_stop(handle);
 }
 
 
-static void idle2_cb(uv_idle_t* handle, int status) {
+static void idle2_cb(uv_idle_t* handle) {
   ticks++;
 }
 
 
-static void timer_cb(uv_timer_t* handle, int status) {
+static void timer_cb(uv_timer_t* handle) {
   uv_idle_stop(&idle_handle);
   uv_timer_stop(&timer_handle);
 }

--- a/test/benchmark-million-async.c
+++ b/test/benchmark-million-async.c
@@ -50,13 +50,13 @@ static void thread_cb(void* arg) {
 }
 
 
-static void async_cb(uv_async_t* handle, int status) {
+static void async_cb(uv_async_t* handle) {
   container->async_events++;
   handle->data = handle;
 }
 
 
-static void timer_cb(uv_timer_t* handle, int status) {
+static void timer_cb(uv_timer_t* handle) {
   unsigned i;
 
   done = 1;

--- a/test/benchmark-million-timers.c
+++ b/test/benchmark-million-timers.c
@@ -28,7 +28,7 @@ static int timer_cb_called;
 static int close_cb_called;
 
 
-static void timer_cb(uv_timer_t* handle, int status) {
+static void timer_cb(uv_timer_t* handle) {
   timer_cb_called++;
 }
 

--- a/test/benchmark-multi-accept.c
+++ b/test/benchmark-multi-accept.c
@@ -90,7 +90,7 @@ static void ipc_alloc_cb(uv_handle_t* handle,
                          size_t suggested_size,
                          uv_buf_t* buf);
 
-static void sv_async_cb(uv_async_t* handle, int status);
+static void sv_async_cb(uv_async_t* handle);
 static void sv_connection_cb(uv_stream_t* server_handle, int status);
 static void sv_read_cb(uv_stream_t* handle, ssize_t nread, const uv_buf_t* buf);
 static void sv_alloc_cb(uv_handle_t* handle,
@@ -98,7 +98,7 @@ static void sv_alloc_cb(uv_handle_t* handle,
                         uv_buf_t* buf);
 
 static void cl_connect_cb(uv_connect_t* req, int status);
-static void cl_idle_cb(uv_idle_t* handle, int status);
+static void cl_idle_cb(uv_idle_t* handle);
 static void cl_close_cb(uv_handle_t* handle);
 
 static struct sockaddr_in listen_addr;
@@ -275,7 +275,7 @@ static void server_cb(void *arg) {
 }
 
 
-static void sv_async_cb(uv_async_t* handle, int status) {
+static void sv_async_cb(uv_async_t* handle) {
   struct server_ctx* ctx;
   ctx = container_of(handle, struct server_ctx, async_handle);
   uv_close((uv_handle_t*) &ctx->server_handle, NULL);
@@ -330,7 +330,7 @@ static void cl_connect_cb(uv_connect_t* req, int status) {
 }
 
 
-static void cl_idle_cb(uv_idle_t* handle, int status) {
+static void cl_idle_cb(uv_idle_t* handle) {
   struct client_ctx* ctx = container_of(handle, struct client_ctx, idle_handle);
   uv_close((uv_handle_t*) &ctx->client_handle, cl_close_cb);
   uv_idle_stop(&ctx->idle_handle);

--- a/test/benchmark-pump.c
+++ b/test/benchmark-pump.c
@@ -85,7 +85,7 @@ static double gbit(int64_t bytes, int64_t passed_ms) {
 }
 
 
-static void show_stats(uv_timer_t* handle, int status) {
+static void show_stats(uv_timer_t* handle) {
   int64_t diff;
   int i;
 

--- a/test/benchmark-udp-pummel.c
+++ b/test/benchmark-udp-pummel.c
@@ -132,7 +132,7 @@ static void close_cb(uv_handle_t* handle) {
 }
 
 
-static void timeout_cb(uv_timer_t* timer, int status) {
+static void timeout_cb(uv_timer_t* timer) {
   int i;
 
   exiting = 1;

--- a/test/test-active.c
+++ b/test/test-active.c
@@ -35,7 +35,7 @@ static void close_cb(uv_handle_t* handle) {
 }
 
 
-static void timer_cb(uv_timer_t* handle, int status) {
+static void timer_cb(uv_timer_t* handle) {
   ASSERT(0 && "timer_cb should not have been called");
 }
 

--- a/test/test-async-null-cb.c
+++ b/test/test-async-null-cb.c
@@ -34,7 +34,7 @@ static void thread_cb(void* dummy) {
 }
 
 
-static void check_cb(uv_check_t* handle, int status) {
+static void check_cb(uv_check_t* handle) {
   ASSERT(check_cb_called == 0);
   uv_close((uv_handle_t*) &async_handle, NULL);
   uv_close((uv_handle_t*) &check_handle, NULL);

--- a/test/test-async.c
+++ b/test/test-async.c
@@ -75,11 +75,10 @@ static void close_cb(uv_handle_t* handle) {
 }
 
 
-static void async_cb(uv_async_t* handle, int status) {
+static void async_cb(uv_async_t* handle) {
   int n;
 
   ASSERT(handle == &async);
-  ASSERT(status == 0);
 
   uv_mutex_lock(&mutex);
   n = ++async_cb_called;
@@ -92,11 +91,10 @@ static void async_cb(uv_async_t* handle, int status) {
 }
 
 
-static void prepare_cb(uv_prepare_t* handle, int status) {
+static void prepare_cb(uv_prepare_t* handle) {
   int r;
 
   ASSERT(handle == &prepare);
-  ASSERT(status == 0);
 
   if (prepare_cb_called++)
     return;

--- a/test/test-callback-order.c
+++ b/test/test-callback-order.c
@@ -30,7 +30,7 @@ static uv_timer_t timer_handle;
 
 
 /* idle_cb should run before timer_cb */
-static void idle_cb(uv_idle_t* handle, int status) {
+static void idle_cb(uv_idle_t* handle) {
   ASSERT(idle_cb_called == 0);
   ASSERT(timer_cb_called == 0);
   uv_idle_stop(handle);
@@ -38,7 +38,7 @@ static void idle_cb(uv_idle_t* handle, int status) {
 }
 
 
-static void timer_cb(uv_timer_t* handle, int status) {
+static void timer_cb(uv_timer_t* handle) {
   ASSERT(idle_cb_called == 1);
   ASSERT(timer_cb_called == 0);
   uv_timer_stop(handle);
@@ -46,7 +46,7 @@ static void timer_cb(uv_timer_t* handle, int status) {
 }
 
 
-static void next_tick(uv_idle_t* handle, int status) {
+static void next_tick(uv_idle_t* handle) {
   uv_loop_t* loop = handle->loop;
   uv_idle_stop(handle);
   uv_idle_init(loop, &idle_handle);

--- a/test/test-callback-stack.c
+++ b/test/test-callback-stack.c
@@ -105,9 +105,8 @@ static void read_cb(uv_stream_t* tcp, ssize_t nread, const uv_buf_t* buf) {
 }
 
 
-static void timer_cb(uv_timer_t* handle, int status) {
+static void timer_cb(uv_timer_t* handle) {
   ASSERT(handle == &timer);
-  ASSERT(status == 0);
   ASSERT(nested == 0 && "timer_cb must be called from a fresh stack");
 
   puts("Timeout complete. Now read data...");

--- a/test/test-close-order.c
+++ b/test/test-close-order.c
@@ -38,7 +38,7 @@ static void close_cb(uv_handle_t* handle) {
 
 
 /* check_cb should run before any close_cb */
-static void check_cb(uv_check_t* handle, int status) {
+static void check_cb(uv_check_t* handle) {
   ASSERT(check_cb_called == 0);
   ASSERT(timer_cb_called == 1);
   ASSERT(close_cb_called == 0);
@@ -48,7 +48,7 @@ static void check_cb(uv_check_t* handle, int status) {
 }
 
 
-static void timer_cb(uv_timer_t* handle, int status) {
+static void timer_cb(uv_timer_t* handle) {
   uv_close((uv_handle_t*) handle, close_cb);
   timer_cb_called++;
 }

--- a/test/test-connection-fail.c
+++ b/test/test-connection-fail.c
@@ -46,8 +46,7 @@ static void timer_close_cb(uv_handle_t* handle) {
 }
 
 
-static void timer_cb(uv_timer_t* handle, int status) {
-  ASSERT(status == 0);
+static void timer_cb(uv_timer_t* handle) {
   timer_cb_calls++;
 
   /*

--- a/test/test-delayed-accept.c
+++ b/test/test-delayed-accept.c
@@ -45,13 +45,12 @@ static void close_cb(uv_handle_t* handle) {
 }
 
 
-static void do_accept(uv_timer_t* timer_handle, int status) {
+static void do_accept(uv_timer_t* timer_handle) {
   uv_tcp_t* server;
   uv_tcp_t* accepted_handle = (uv_tcp_t*)malloc(sizeof *accepted_handle);
   int r;
 
   ASSERT(timer_handle != NULL);
-  ASSERT(status == 0);
   ASSERT(accepted_handle != NULL);
 
   r = uv_tcp_init(uv_default_loop(), accepted_handle);

--- a/test/test-embed.c
+++ b/test/test-embed.c
@@ -90,14 +90,14 @@ static void embed_thread_runner(void* arg) {
 }
 
 
-static void embed_cb(uv_async_t* async, int status) {
+static void embed_cb(uv_async_t* async) {
   uv_run(uv_default_loop(), UV_RUN_ONCE);
 
   uv_sem_post(&embed_sem);
 }
 
 
-static void embed_timer_cb(uv_timer_t* timer, int status) {
+static void embed_timer_cb(uv_timer_t* timer) {
   embed_timer_called++;
   embed_closed = 1;
 

--- a/test/test-fs-event.c
+++ b/test/test-fs-event.c
@@ -50,7 +50,7 @@ static char fs_event_filename[1024];
 #endif  /* defined(PATH_MAX) */
 static int timer_cb_touch_called;
 
-static void fs_event_unlink_files(uv_timer_t* handle, int status);
+static void fs_event_unlink_files(uv_timer_t* handle);
 
 static void create_dir(uv_loop_t* loop, const char* name) {
   int r;
@@ -147,7 +147,7 @@ static const char* fs_event_get_filename(int i) {
   return fs_event_filename;
 }
 
-static void fs_event_create_files(uv_timer_t* handle, int status) {
+static void fs_event_create_files(uv_timer_t* handle) {
   int i;
 
   /* Already created all files */
@@ -164,7 +164,7 @@ static void fs_event_create_files(uv_timer_t* handle, int status) {
   ASSERT(0 == uv_timer_start(&timer, fs_event_unlink_files, 50, 0));
 }
 
-void fs_event_unlink_files(uv_timer_t* handle, int status) {
+void fs_event_unlink_files(uv_timer_t* handle) {
   int r;
   int i;
 
@@ -193,11 +193,10 @@ static void fs_event_cb_file(uv_fs_event_t* handle, const char* filename,
   uv_close((uv_handle_t*)handle, close_cb);
 }
 
-static void timer_cb_close_handle(uv_timer_t* timer, int status) {
+static void timer_cb_close_handle(uv_timer_t* timer) {
   uv_handle_t* handle;
 
   ASSERT(timer != NULL);
-  ASSERT(status == 0);
   handle = timer->data;
 
   uv_close((uv_handle_t*)timer, NULL);
@@ -223,7 +222,7 @@ static void fs_event_cb_file_current_dir(uv_fs_event_t* handle,
   }
 }
 
-static void timer_cb_file(uv_timer_t* handle, int status) {
+static void timer_cb_file(uv_timer_t* handle) {
   ++timer_cb_called;
 
   if (timer_cb_called == 1) {
@@ -234,14 +233,13 @@ static void timer_cb_file(uv_timer_t* handle, int status) {
   }
 }
 
-static void timer_cb_touch(uv_timer_t* timer, int status) {
-  ASSERT(status == 0);
+static void timer_cb_touch(uv_timer_t* timer) {
   uv_close((uv_handle_t*)timer, NULL);
   touch_file(timer->loop, "watch_file");
   timer_cb_touch_called++;
 }
 
-static void timer_cb_watch_twice(uv_timer_t* handle, int status) {
+static void timer_cb_watch_twice(uv_timer_t* handle) {
   uv_fs_event_t* handles = handle->data;
   uv_close((uv_handle_t*) (handles + 0), NULL);
   uv_close((uv_handle_t*) (handles + 1), NULL);
@@ -253,7 +251,7 @@ TEST_IMPL(fs_event_watch_dir) {
   int r;
 
   /* Setup */
-  fs_event_unlink_files(NULL, 0);
+  fs_event_unlink_files(NULL);
   remove("watch_dir/file2");
   remove("watch_dir/file1");
   remove("watch_dir/");
@@ -275,7 +273,7 @@ TEST_IMPL(fs_event_watch_dir) {
   ASSERT(close_cb_called == 2);
 
   /* Cleanup */
-  fs_event_unlink_files(NULL, 0);
+  fs_event_unlink_files(NULL);
   remove("watch_dir/file2");
   remove("watch_dir/file1");
   remove("watch_dir/");
@@ -458,10 +456,8 @@ static void fs_event_fail(uv_fs_event_t* handle, const char* filename,
 }
 
 
-static void timer_cb(uv_timer_t* handle, int status) {
+static void timer_cb(uv_timer_t* handle) {
   int r;
-
-  ASSERT(status == 0);
 
   r = uv_fs_event_init(handle->loop, &fs_event);
   ASSERT(r == 0);
@@ -672,7 +668,7 @@ static void fs_event_error_report_cb(uv_fs_event_t* handle,
     fs_event_error_reported = status;
 }
 
-static void timer_cb_nop(uv_timer_t* handle, int status) {
+static void timer_cb_nop(uv_timer_t* handle) {
   ++timer_cb_called;
   uv_close((uv_handle_t*) handle, close_cb);
 }

--- a/test/test-fs-poll.c
+++ b/test/test-fs-poll.c
@@ -26,7 +26,7 @@
 
 #define FIXTURE "testfile"
 
-static void timer_cb(uv_timer_t* handle, int status);
+static void timer_cb(uv_timer_t* handle);
 static void close_cb(uv_handle_t* handle);
 static void poll_cb(uv_fs_poll_t* handle,
                     int status,
@@ -71,7 +71,7 @@ static void close_cb(uv_handle_t* handle) {
 }
 
 
-static void timer_cb(uv_timer_t* handle, int status) {
+static void timer_cb(uv_timer_t* handle) {
   touch_file(FIXTURE);
   timer_cb_called++;
 }

--- a/test/test-idle.c
+++ b/test/test-idle.c
@@ -38,9 +38,8 @@ static void close_cb(uv_handle_t* handle) {
 }
 
 
-static void timer_cb(uv_timer_t* handle, int status) {
+static void timer_cb(uv_timer_t* handle) {
   ASSERT(handle == &timer_handle);
-  ASSERT(status == 0);
 
   uv_close((uv_handle_t*) &idle_handle, close_cb);
   uv_close((uv_handle_t*) &check_handle, close_cb);
@@ -51,18 +50,16 @@ static void timer_cb(uv_timer_t* handle, int status) {
 }
 
 
-static void idle_cb(uv_idle_t* handle, int status) {
+static void idle_cb(uv_idle_t* handle) {
   ASSERT(handle == &idle_handle);
-  ASSERT(status == 0);
 
   idle_cb_called++;
   LOGF("idle_cb %d\n", idle_cb_called);
 }
 
 
-static void check_cb(uv_check_t* handle, int status) {
+static void check_cb(uv_check_t* handle) {
   ASSERT(handle == &check_handle);
-  ASSERT(status == 0);
 
   check_cb_called++;
   LOGF("check_cb %d\n", check_cb_called);

--- a/test/test-loop-alive.c
+++ b/test/test-loop-alive.c
@@ -24,9 +24,8 @@
 
 static uv_timer_t timer_handle;
 
-static void timer_cb(uv_timer_t* handle, int status) {
+static void timer_cb(uv_timer_t* handle) {
   ASSERT(handle);
-  ASSERT(status == 0);
 }
 
 

--- a/test/test-loop-close.c
+++ b/test/test-loop-close.c
@@ -24,9 +24,8 @@
 
 static uv_timer_t timer_handle;
 
-static void timer_cb(uv_timer_t* handle, int status) {
+static void timer_cb(uv_timer_t* handle) {
   ASSERT(handle);
-  ASSERT(status == 0);
   uv_stop(handle->loop);
 }
 

--- a/test/test-loop-handles.c
+++ b/test/test-loop-handles.c
@@ -107,9 +107,8 @@ static int idle_2_cb_started = 0;
 static int idle_2_is_active = 0;
 
 
-static void timer_cb(uv_timer_t* handle, int status) {
+static void timer_cb(uv_timer_t* handle) {
   ASSERT(handle == &timer_handle);
-  ASSERT(status == 0);
 }
 
 
@@ -125,11 +124,10 @@ static void idle_2_close_cb(uv_handle_t* handle) {
 }
 
 
-static void idle_2_cb(uv_idle_t* handle, int status) {
+static void idle_2_cb(uv_idle_t* handle) {
   LOG("IDLE_2_CB\n");
 
   ASSERT(handle == &idle_2_handle);
-  ASSERT(status == 0);
 
   idle_2_cb_called++;
 
@@ -137,14 +135,12 @@ static void idle_2_cb(uv_idle_t* handle, int status) {
 }
 
 
-static void idle_1_cb(uv_idle_t* handle, int status) {
+static void idle_1_cb(uv_idle_t* handle) {
   int r;
 
   LOG("IDLE_1_CB\n");
 
   ASSERT(handle != NULL);
-  ASSERT(status == 0);
-
   ASSERT(idles_1_active > 0);
 
   /* Init idle_2 and make it active */
@@ -200,13 +196,12 @@ static void prepare_2_close_cb(uv_handle_t* handle) {
 }
 
 
-static void check_cb(uv_check_t* handle, int status) {
+static void check_cb(uv_check_t* handle) {
   int i, r;
 
   LOG("CHECK_CB\n");
 
   ASSERT(handle == &check_handle);
-  ASSERT(status == 0);
 
   if (loop_iteration < ITERATIONS) {
     /* Make some idle watchers active */
@@ -237,13 +232,12 @@ static void check_cb(uv_check_t* handle, int status) {
 }
 
 
-static void prepare_2_cb(uv_prepare_t* handle, int status) {
+static void prepare_2_cb(uv_prepare_t* handle) {
   int r;
 
   LOG("PREPARE_2_CB\n");
 
   ASSERT(handle == &prepare_2_handle);
-  ASSERT(status == 0);
 
   /* prepare_2 gets started by prepare_1 when (loop_iteration % 2 == 0), */
   /* and it stops itself immediately. A started watcher is not queued */
@@ -258,13 +252,12 @@ static void prepare_2_cb(uv_prepare_t* handle, int status) {
 }
 
 
-static void prepare_1_cb(uv_prepare_t* handle, int status) {
+static void prepare_1_cb(uv_prepare_t* handle) {
   int r;
 
   LOG("PREPARE_1_CB\n");
 
   ASSERT(handle == &prepare_1_handle);
-  ASSERT(status == 0);
 
   if (loop_iteration % 2 == 0) {
     r = uv_prepare_start(&prepare_2_handle, prepare_2_cb);

--- a/test/test-loop-stop.c
+++ b/test/test-loop-stop.c
@@ -29,18 +29,16 @@ static int timer_called = 0;
 static int num_ticks = 10;
 
 
-static void prepare_cb(uv_prepare_t* handle, int status) {
+static void prepare_cb(uv_prepare_t* handle) {
   ASSERT(handle == &prepare_handle);
-  ASSERT(status == 0);
   prepare_called++;
   if (prepare_called == num_ticks)
     uv_prepare_stop(handle);
 }
 
 
-static void timer_cb(uv_timer_t* handle, int status) {
+static void timer_cb(uv_timer_t* handle) {
   ASSERT(handle == &timer_handle);
-  ASSERT(status == 0);
   timer_called++;
   if (timer_called == 1)
     uv_stop(uv_default_loop());

--- a/test/test-poll.c
+++ b/test/test-poll.c
@@ -61,7 +61,7 @@ typedef struct server_context_s {
 } server_context_t;
 
 
-static void delay_timer_cb(uv_timer_t* timer, int status);
+static void delay_timer_cb(uv_timer_t* timer);
 
 
 static test_mode_t test_mode = DUPLEX;
@@ -413,7 +413,7 @@ static void connection_poll_cb(uv_poll_t* handle, int status, int events) {
 }
 
 
-static void delay_timer_cb(uv_timer_t* timer, int status) {
+static void delay_timer_cb(uv_timer_t* timer) {
   connection_context_t* context = (connection_context_t*) timer->data;
   int r;
 

--- a/test/test-ref.c
+++ b/test/test-ref.c
@@ -153,9 +153,8 @@ TEST_IMPL(check_ref) {
 }
 
 
-static void prepare_cb(uv_prepare_t* h, int status) {
+static void prepare_cb(uv_prepare_t* h) {
   ASSERT(h != NULL);
-  ASSERT(status == 0);
   uv_unref((uv_handle_t*)h);
 }
 

--- a/test/test-run-nowait.c
+++ b/test/test-run-nowait.c
@@ -26,9 +26,8 @@ static uv_timer_t timer_handle;
 static int timer_called = 0;
 
 
-static void timer_cb(uv_timer_t* handle, int status) {
+static void timer_cb(uv_timer_t* handle) {
   ASSERT(handle == &timer_handle);
-  ASSERT(status == 0);
   timer_called = 1;
 }
 

--- a/test/test-run-once.c
+++ b/test/test-run-once.c
@@ -28,9 +28,8 @@ static uv_idle_t idle_handle;
 static int idle_counter;
 
 
-static void idle_cb(uv_idle_t* handle, int status) {
+static void idle_cb(uv_idle_t* handle) {
   ASSERT(handle == &idle_handle);
-  ASSERT(status == 0);
 
   if (++idle_counter == NUM_TICKS)
     uv_idle_stop(handle);

--- a/test/test-shutdown-eof.c
+++ b/test/test-shutdown-eof.c
@@ -123,7 +123,7 @@ static void timer_close_cb(uv_handle_t* handle) {
 }
 
 
-static void timer_cb(uv_timer_t* handle, int status) {
+static void timer_cb(uv_timer_t* handle) {
   ASSERT(handle == &timer);
   uv_close((uv_handle_t*) handle, timer_close_cb);
 

--- a/test/test-signal.c
+++ b/test/test-signal.c
@@ -65,7 +65,7 @@ static void signal_cb(uv_signal_t* handle, int signum) {
 }
 
 
-static void timer_cb(uv_timer_t* handle, int status) {
+static void timer_cb(uv_timer_t* handle) {
   struct timer_ctx* ctx = container_of(handle, struct timer_ctx, handle);
 
   raise(ctx->signum);

--- a/test/test-spawn.c
+++ b/test/test-spawn.c
@@ -146,13 +146,13 @@ static void init_process_options(char* test, uv_exit_cb exit_cb) {
 }
 
 
-static void timer_cb(uv_timer_t* handle, int status) {
+static void timer_cb(uv_timer_t* handle) {
   uv_process_kill(&process, /* SIGTERM */ 15);
   uv_close((uv_handle_t*)handle, close_cb);
 }
 
 
-static void timer_counter_cb(uv_timer_t* handle, int status) {
+static void timer_counter_cb(uv_timer_t* handle) {
   ++timer_counter;
 }
 

--- a/test/test-tcp-close-while-connecting.c
+++ b/test/test-tcp-close-while-connecting.c
@@ -43,14 +43,14 @@ static void connect_cb(uv_connect_t* req, int status) {
 }
 
 
-static void timer1_cb(uv_timer_t* handle, int status) {
+static void timer1_cb(uv_timer_t* handle) {
   uv_close((uv_handle_t*)handle, close_cb);
   uv_close((uv_handle_t*)&tcp_handle, close_cb);
   timer1_cb_called++;
 }
 
 
-static void timer2_cb(uv_timer_t* handle, int status) {
+static void timer2_cb(uv_timer_t* handle) {
   ASSERT(0 && "should not be called");
 }
 

--- a/test/test-tcp-connect-timeout.c
+++ b/test/test-tcp-connect-timeout.c
@@ -33,7 +33,7 @@ static uv_timer_t timer;
 static uv_tcp_t conn;
 
 static void connect_cb(uv_connect_t* req, int status);
-static void timer_cb(uv_timer_t* handle, int status);
+static void timer_cb(uv_timer_t* handle);
 static void close_cb(uv_handle_t* handle);
 
 
@@ -44,7 +44,7 @@ static void connect_cb(uv_connect_t* req, int status) {
 }
 
 
-static void timer_cb(uv_timer_t* handle, int status) {
+static void timer_cb(uv_timer_t* handle) {
   ASSERT(handle == &timer);
   uv_close((uv_handle_t*)&conn, close_cb);
   uv_close((uv_handle_t*)&timer, close_cb);

--- a/test/test-tcp-read-stop.c
+++ b/test/test-tcp-read-stop.c
@@ -38,7 +38,7 @@ static void write_cb(uv_write_t* req, int status) {
 }
 
 
-static void timer_cb(uv_timer_t* handle, int status) {
+static void timer_cb(uv_timer_t* handle) {
   uv_buf_t buf = uv_buf_init("PING", 4);
   ASSERT(0 == uv_write(&write_req,
                        (uv_stream_t*) &tcp_handle,

--- a/test/test-tcp-shutdown-after-write.c
+++ b/test/test-tcp-shutdown-after-write.c
@@ -58,7 +58,7 @@ static void alloc_cb(uv_handle_t* handle,
 }
 
 
-static void timer_cb(uv_timer_t* handle, int status) {
+static void timer_cb(uv_timer_t* handle) {
   uv_buf_t buf;
   int r;
 

--- a/test/test-tcp-unexpected-read.c
+++ b/test/test-tcp-unexpected-read.c
@@ -33,12 +33,12 @@ static uv_connect_t connect_req;
 static unsigned long ticks; /* event loop ticks */
 
 
-static void check_cb(uv_check_t* handle, int status) {
+static void check_cb(uv_check_t* handle) {
   ticks++;
 }
 
 
-static void timer_cb(uv_timer_t* handle, int status) {
+static void timer_cb(uv_timer_t* handle) {
   uv_close((uv_handle_t*) &check_handle, NULL);
   uv_close((uv_handle_t*) &timer_handle, NULL);
   uv_close((uv_handle_t*) &server_handle, NULL);

--- a/test/test-threadpool-cancel.c
+++ b/test/test-threadpool-cancel.c
@@ -138,7 +138,7 @@ static void done2_cb(uv_work_t* req, int status) {
 }
 
 
-static void timer_cb(uv_timer_t* handle, int status) {
+static void timer_cb(uv_timer_t* handle) {
   struct cancel_info* ci;
   uv_req_t* req;
   unsigned i;

--- a/test/test-timer-again.c
+++ b/test/test-timer-again.c
@@ -41,12 +41,10 @@ static void close_cb(uv_handle_t* handle) {
 }
 
 
-static void repeat_1_cb(uv_timer_t* handle, int status) {
+static void repeat_1_cb(uv_timer_t* handle) {
   int r;
 
   ASSERT(handle == &repeat_1);
-  ASSERT(status == 0);
-
   ASSERT(uv_timer_get_repeat((uv_timer_t*)handle) == 50);
 
   LOGF("repeat_1_cb called after %ld ms\n",
@@ -67,9 +65,8 @@ static void repeat_1_cb(uv_timer_t* handle, int status) {
 }
 
 
-static void repeat_2_cb(uv_timer_t* handle, int status) {
+static void repeat_2_cb(uv_timer_t* handle) {
   ASSERT(handle == &repeat_2);
-  ASSERT(status == 0);
   ASSERT(repeat_2_cb_allowed);
 
   LOGF("repeat_2_cb called after %ld ms\n",

--- a/test/test-timer-from-check.c
+++ b/test/test-timer-from-check.c
@@ -31,7 +31,7 @@ static int check_cb_called;
 static int timer_cb_called;
 
 
-static void prepare_cb(uv_prepare_t* handle, int status) {
+static void prepare_cb(uv_prepare_t* handle) {
   ASSERT(0 == uv_prepare_stop(&prepare_handle));
   ASSERT(0 == prepare_cb_called);
   ASSERT(1 == check_cb_called);
@@ -40,7 +40,7 @@ static void prepare_cb(uv_prepare_t* handle, int status) {
 }
 
 
-static void timer_cb(uv_timer_t* handle, int status) {
+static void timer_cb(uv_timer_t* handle) {
   ASSERT(0 == uv_timer_stop(&timer_handle));
   ASSERT(1 == prepare_cb_called);
   ASSERT(1 == check_cb_called);
@@ -49,7 +49,7 @@ static void timer_cb(uv_timer_t* handle, int status) {
 }
 
 
-static void check_cb(uv_check_t* handle, int status) {
+static void check_cb(uv_check_t* handle) {
   ASSERT(0 == uv_check_stop(&check_handle));
   ASSERT(0 == uv_timer_stop(&timer_handle));  /* Runs before timer_cb. */
   ASSERT(0 == uv_timer_start(&timer_handle, timer_cb, 50, 0));

--- a/test/test-timer.c
+++ b/test/test-timer.c
@@ -44,11 +44,10 @@ static void once_close_cb(uv_handle_t* handle) {
 }
 
 
-static void once_cb(uv_timer_t* handle, int status) {
+static void once_cb(uv_timer_t* handle) {
   printf("ONCE_CB %d\n", once_cb_called);
 
   ASSERT(handle != NULL);
-  ASSERT(status == 0);
   ASSERT(0 == uv_is_active((uv_handle_t*) handle));
 
   once_cb_called++;
@@ -69,11 +68,10 @@ static void repeat_close_cb(uv_handle_t* handle) {
 }
 
 
-static void repeat_cb(uv_timer_t* handle, int status) {
+static void repeat_cb(uv_timer_t* handle) {
   printf("REPEAT_CB\n");
 
   ASSERT(handle != NULL);
-  ASSERT(status == 0);
   ASSERT(1 == uv_is_active((uv_handle_t*) handle));
 
   repeat_cb_called++;
@@ -84,7 +82,7 @@ static void repeat_cb(uv_timer_t* handle, int status) {
 }
 
 
-static void never_cb(uv_timer_t* handle, int status) {
+static void never_cb(uv_timer_t* handle) {
   FATAL("never_cb should never be called");
 }
 
@@ -170,12 +168,12 @@ TEST_IMPL(timer_init) {
 }
 
 
-static void order_cb_a(uv_timer_t *handle, int status) {
+static void order_cb_a(uv_timer_t *handle) {
   ASSERT(order_cb_called++ == *(int*)handle->data);
 }
 
 
-static void order_cb_b(uv_timer_t *handle, int status) {
+static void order_cb_b(uv_timer_t *handle) {
   ASSERT(order_cb_called++ == *(int*)handle->data);
 }
 
@@ -219,7 +217,7 @@ TEST_IMPL(timer_order) {
 }
 
 
-static void tiny_timer_cb(uv_timer_t* handle, int status) {
+static void tiny_timer_cb(uv_timer_t* handle) {
   ASSERT(handle == &tiny_timer);
   uv_close((uv_handle_t*) &tiny_timer, NULL);
   uv_close((uv_handle_t*) &huge_timer1, NULL);
@@ -240,7 +238,7 @@ TEST_IMPL(timer_huge_timeout) {
 }
 
 
-static void huge_repeat_cb(uv_timer_t* handle, int status) {
+static void huge_repeat_cb(uv_timer_t* handle) {
   static int ncalls;
 
   if (ncalls == 0)
@@ -269,7 +267,7 @@ TEST_IMPL(timer_huge_repeat) {
 static unsigned int timer_run_once_timer_cb_called;
 
 
-static void timer_run_once_timer_cb(uv_timer_t* handle, int status) {
+static void timer_run_once_timer_cb(uv_timer_t* handle) {
   timer_run_once_timer_cb_called++;
 }
 

--- a/test/test-udp-ipv6.c
+++ b/test/test-udp-ipv6.c
@@ -90,7 +90,7 @@ static void ipv6_recv_ok(uv_udp_t* handle,
 }
 
 
-static void timeout_cb(uv_timer_t* timer, int status) {
+static void timeout_cb(uv_timer_t* timer) {
   uv_close((uv_handle_t*)&server, close_cb);
   uv_close((uv_handle_t*)&client, close_cb);
   uv_close((uv_handle_t*)&timeout, close_cb);

--- a/test/test-walk-handles.c
+++ b/test/test-walk-handles.c
@@ -41,9 +41,8 @@ static void walk_cb(uv_handle_t* handle, void* arg) {
 }
 
 
-static void timer_cb(uv_timer_t* handle, int status) {
+static void timer_cb(uv_timer_t* handle) {
   ASSERT(handle == &timer);
-  ASSERT(status == 0);
 
   uv_walk(handle->loop, walk_cb, magic_cookie);
   uv_close((uv_handle_t*)handle, NULL);


### PR DESCRIPTION
async, timer, prepare, idle and check handles don't need the status parameter.

So, this closes issue #40.

I understand this will require many changes on dependant projects (mine included), but I'd go for it because it's just more correct. Also changes are pretty simple :-)

Now, since we seem to be pretty close to v0.12, we could merge this after, I'd also be ok with that.

/cc @indutny, @piscisaureus, @bnoordhuis
