### PR TITLE
enable to configure with older versions of autoconf

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -16,6 +16,7 @@ AC_PREREQ(2.57)
 AC_INIT([libuv], [0.11.23], [https://github.com/joyent/libuv/issues])
 AC_CONFIG_MACRO_DIR([m4])
 m4_include([m4/libuv-extra-automake-flags.m4])
+m4_include([m4/as_case.m4])
 AM_INIT_AUTOMAKE([-Wall -Werror foreign subdir-objects] UV_EXTRA_AUTOMAKE_FLAGS)
 AC_CANONICAL_HOST
 AC_ENABLE_SHARED

--- a/m4/as_case.m4
+++ b/m4/as_case.m4
@@ -1,0 +1,21 @@
+# AS_CASE(WORD, [PATTERN1], [IF-MATCHED1]...[DEFAULT])
+# ----------------------------------------------------
+# Expand into
+# | case WORD in
+# | PATTERN1) IF-MATCHED1 ;;
+# | ...
+# | *) DEFAULT ;;
+# | esac
+m4_define([_AS_CASE],
+[m4_if([$#], 0, [m4_fatal([$0: too few arguments: $#])],
+       [$#], 1, [  *) $1 ;;],
+       [$#], 2, [  $1) m4_default([$2], [:]) ;;],
+       [  $1) m4_default([$2], [:]) ;;
+$0(m4_shiftn(2, $@))])dnl
+])
+m4_defun([AS_CASE],
+[m4_ifval([$2$3],
+[case $1 in
+_AS_CASE(m4_shift($@))
+esac])])
+


### PR DESCRIPTION
https://github.com/joyent/libuv/issues/1158
(already closed)

configure.ac at master: AC_PREREQ(2.57)
This means that libuv is enable to configure with autoconf version 2.57 or newer.

But AS_CASE is enable to use autoconf 2.60 or newer version.And AS_CASE has a BUG until version 2.69.
So AC_PREREQ(2.69) might be more better solution.

If you can support older versions of autoconf, please check this patch.
Regards and great thanks for your very useful software.
