### PR TITLE
windows: Fix an infinite loop in uv_spawn

### DIFF
--- a/src/win/process.c
+++ b/src/win/process.c
@@ -378,7 +378,7 @@ static WCHAR* search_path(const WCHAR *file,
       }
 
       /* Skip the separator that dir_end now points to */
-      if (dir_end != path) {
+      if (dir_end != path || *path == L';') {
         dir_end++;
       }
 

--- a/test/test-list.h
+++ b/test/test-list.h
@@ -244,6 +244,7 @@ TEST_DECLARE   (environment_creation)
 TEST_DECLARE   (listen_with_simultaneous_accepts)
 TEST_DECLARE   (listen_no_simultaneous_accepts)
 TEST_DECLARE   (fs_stat_root)
+TEST_DECLARE   (spawn_with_an_odd_path)
 #else
 TEST_DECLARE   (emfile)
 TEST_DECLARE   (close_fd)
@@ -500,6 +501,7 @@ TASK_LIST_START
   TEST_ENTRY  (listen_with_simultaneous_accepts)
   TEST_ENTRY  (listen_no_simultaneous_accepts)
   TEST_ENTRY  (fs_stat_root)
+  TEST_ENTRY  (spawn_with_an_odd_path)
 #else
   TEST_ENTRY  (emfile)
   TEST_ENTRY  (close_fd)

--- a/test/test-spawn.c
+++ b/test/test-spawn.c
@@ -171,6 +171,7 @@ TEST_IMPL(spawn_fails) {
   r = uv_spawn(uv_default_loop(), &process, &options);
   ASSERT(r == UV_ENOENT || r == UV_EACCES);
   ASSERT(0 == uv_is_active((uv_handle_t*) &process));
+  uv_close((uv_handle_t*) &process, NULL);
   ASSERT(0 == uv_run(uv_default_loop(), UV_RUN_DEFAULT));
 
   MAKE_VALGRIND_HAPPY();


### PR DESCRIPTION
The PATH-parsing code for windows erroneously contained an infinite
loop when the PATH started with a leading semicolon. Each iteration of
the loop usually bumped over the separator, but if the first character
was a semicolon then it would never skip it, causing the infinite
loop.

Closes #909
