### PR TITLE
bsd: support IPv6 qualified link-local addresses

### DIFF
--- a/include/uv-bsd.h
+++ b/include/uv-bsd.h
@@ -31,4 +31,6 @@
 
 #define UV_HAVE_KQUEUE 1
 
+#define UV_PLATFORM_HAS_IP6_LINK_LOCAL_ADDRESS
+
 #endif /* UV_BSD_H */


### PR DESCRIPTION
AFAICT (online man pages) all BSDs we support have `if_nametoindex` in net/if.h, so use it. Tested on FreeBSD 10.

/cc @indutny @bnoordhuis
