### PR TITLE
sunos: support IPv6 qualified link-local addresses

### DIFF
--- a/include/uv-sunos.h
+++ b/include/uv-sunos.h
@@ -41,4 +41,6 @@
 
 #endif /* defined(PORT_SOURCE_FILE) */
 
+#define UV_PLATFORM_HAS_IP6_LINK_LOCAL_ADDRESS
+
 #endif /* UV_SUNOS_H */


### PR DESCRIPTION
/cc @tjfontaine

AFAIS all SunOS variants seem to support it.
