### PR TITLE
windows: console signal handler, add refs not correct

### DIFF
--- a/src/win/signal.c
+++ b/src/win/signal.c
@@ -130,8 +130,10 @@ static int uv__signal_register_control_handler() {
 
   /* If the console control handler has already been hooked, just add a */
   /* reference. */
-  if (uv__signal_control_handler_refs > 0)
+  if (uv__signal_control_handler_refs > 0) {
+    uv__signal_control_handler_refs++;
     return 0;
+  }
 
   if (!SetConsoleCtrlHandler(uv__signal_control_handler, TRUE))
     return GetLastError();


### PR DESCRIPTION
If the console control handler has already been hooked, add a reference.
pool english, sorry.
