### PR TITLE
inet: allow scopeid in uv_inet_pton

### DIFF
--- a/test/test-ip6-addr.c
+++ b/test/test-ip6-addr.c
@@ -97,3 +97,45 @@ TEST_IMPL(ip6_addr_link_local) {
   RETURN_SKIP("Qualified link-local addresses are not supported.");
 #endif
 }
+
+
+#define GOOD_ADDR_LIST(X)                                                     \
+    X("::")                                                                   \
+    X("::1")                                                                  \
+    X("fe80::1")                                                              \
+    X("fe80::")                                                               \
+    X("fe80::2acf:daff:fedd:342a")                                            \
+    X("fe80:0:0:0:2acf:daff:fedd:342a")                                       \
+    X("fe80:0:0:0:2acf:daff:1.2.3.4")                                         \
+
+#define BAD_ADDR_LIST(X)                                                      \
+    X(":::1")                                                                 \
+    X("abcde::1")                                                             \
+    X("fe80:0:0:0:2acf:daff:fedd:342a:5678")                                  \
+    X("fe80:0:0:0:2acf:daff:abcd:1.2.3.4")                                    \
+    X("fe80:0:0:2acf:daff:1.2.3.4.5")                                         \
+
+#define TEST_GOOD(ADDR)                                                       \
+    ASSERT(0 == uv_inet_pton(AF_INET6, ADDR, &addr));                         \
+    ASSERT(0 == uv_inet_pton(AF_INET6, ADDR "%en1", &addr));                  \
+    ASSERT(0 == uv_inet_pton(AF_INET6, ADDR "%%%%", &addr));                  \
+    ASSERT(0 == uv_inet_pton(AF_INET6, ADDR "%en1:1.2.3.4", &addr));          \
+
+#define TEST_BAD(ADDR)                                                        \
+    ASSERT(0 != uv_inet_pton(AF_INET6, ADDR, &addr));                         \
+    ASSERT(0 != uv_inet_pton(AF_INET6, ADDR "%en1", &addr));                  \
+    ASSERT(0 != uv_inet_pton(AF_INET6, ADDR "%%%%", &addr));                  \
+    ASSERT(0 != uv_inet_pton(AF_INET6, ADDR "%en1:1.2.3.4", &addr));          \
+
+TEST_IMPL(ip6_pton) {
+  struct in6_addr addr;
+
+  GOOD_ADDR_LIST(TEST_GOOD)
+  BAD_ADDR_LIST(TEST_BAD)
+
+  MAKE_VALGRIND_HAPPY();
+  return 0;
+}
+
+#undef GOOD_ADDR_LIST
+#undef BAD_ADDR_LIST

--- a/test/test-list.h
+++ b/test/test-list.h
@@ -41,6 +41,7 @@ TEST_DECLARE   (semaphore_2)
 TEST_DECLARE   (semaphore_3)
 TEST_DECLARE   (tty)
 TEST_DECLARE   (stdio_over_pipes)
+TEST_DECLARE   (ip6_pton)
 TEST_DECLARE   (ipc_listen_before_write)
 TEST_DECLARE   (ipc_listen_after_write)
 #ifndef _WIN32
@@ -295,6 +296,7 @@ TASK_LIST_START
   TEST_ENTRY  (pipe_server_close)
   TEST_ENTRY  (tty)
   TEST_ENTRY  (stdio_over_pipes)
+  TEST_ENTRY  (ip6_pton)
   TEST_ENTRY  (ipc_listen_before_write)
   TEST_ENTRY  (ipc_listen_after_write)
 #ifndef _WIN32

--- a/uv.gyp
+++ b/uv.gyp
@@ -321,6 +321,7 @@
         'test/test-getsockname.c',
         'test/test-hrtime.c',
         'test/test-idle.c',
+        'test/test-ip6-addr.c',
         'test/test-ipc.c',
         'test/test-ipc-send-recv.c',
         'test/test-list.h',


### PR DESCRIPTION
We already support it in `uv_ip6_addr` anyway.

See https://github.com/joyent/node/issues/7395
