### PR TITLE
test: fix for echo-server.c assert failure; addition to print uv error information

### DIFF
--- a/test/echo-server.c
+++ b/test/echo-server.c
@@ -51,24 +51,20 @@ static void after_write(uv_write_t* req, int status) {
   /* Free the read/write buffer and the request */
   wr = (write_req_t*) req;
   free(wr->buf.base);
+
+  if (status == 0) {
+    free(wr);
+    return;
+  }
+
+  fprintf(stderr,
+          "uv_write error: %s - %s\n",
+          uv_err_name(status),
+          uv_strerror(status));
+
+  if (!uv_is_closing((uv_handle_t*) req->handle))
+    uv_close((uv_handle_t*) req->handle, on_close);
   free(wr);
-
-  if (status == 0)
-    return;
-
-  fprintf(stderr, "uv_write error: %s\n", uv_strerror(status));
-
-  if (status == UV_ECANCELED)
-    return;
-
-  ASSERT(status == UV_EPIPE);
-  uv_close((uv_handle_t*)req->handle, on_close);
-}
-
-
-static void after_shutdown(uv_shutdown_t* req, int status) {
-  uv_close((uv_handle_t*)req->handle, on_close);
-  free(req);
 }
 
 
@@ -77,7 +73,6 @@ static void after_read(uv_stream_t* handle,
                        const uv_buf_t* buf) {
   int i;
   write_req_t *wr;
-  uv_shutdown_t* req;
 
   if (nread < 0) {
     /* Error or EOF */
@@ -87,9 +82,7 @@ static void after_read(uv_stream_t* handle,
       free(buf->base);
     }
 
-    req = (uv_shutdown_t*) malloc(sizeof *req);
-    uv_shutdown(req, handle, after_shutdown);
-
+    uv_close((uv_handle_t*) handle, on_close);
     return;
   }
 


### PR DESCRIPTION
First commit simply fixes https://github.com/joyent/libuv/issues/1244

Second one is an additional macro that will print a lot of information about libuv specific errors. This patch replaces a few areas that simply did a `return 1;` with always running `abort()`. If not acceptable then I'll work around it.
