### PR TITLE
windows: fix build error

### DIFF
--- a/src/win/tcp.c
+++ b/src/win/tcp.c
@@ -243,11 +243,13 @@ static int uv_tcp_try_bind(uv_tcp_t* handle,
   int r;
 
   if (handle->socket == INVALID_SOCKET) {
+    SOCKET sock;
+    
     /* Cannot set IPv6-only mode on non-IPv6 socket. */
     if ((flags & UV_TCP_IPV6ONLY) && addr->sa_family != AF_INET6)
       return ERROR_INVALID_PARAMETER;
 
-    SOCKET sock = socket(addr->sa_family, SOCK_STREAM, 0);
+    sock = socket(addr->sa_family, SOCK_STREAM, 0);
     if (sock == INVALID_SOCKET) {
       return WSAGetLastError();
     }


### PR DESCRIPTION
Previously using Windows DevKit 8.1
`src\win\tcp.c(250): error C2275: 'SOCKET' : illegal use of this type as an expression`
