### PR TITLE
unix: handle case when addr is not initialized after recvmsg

### DIFF
--- a/src/unix/udp.c
+++ b/src/unix/udp.c
@@ -221,16 +221,17 @@ static void uv__udp_recvmsg(uv_loop_t* loop,
         handle->recv_cb(handle, -errno, &buf, NULL, 0);
     }
     else {
-      flags = 0;
+      const struct sockaddr *addr;
+      if (h.msg_namelen == 0)
+        addr = NULL;
+      else
+        addr = (const struct sockaddr*) &peer;
 
+      flags = 0;
       if (h.msg_flags & MSG_TRUNC)
         flags |= UV_UDP_PARTIAL;
 
-      handle->recv_cb(handle,
-                      nread,
-                      &buf,
-                      (const struct sockaddr*) &peer,
-                      flags);
+      handle->recv_cb(handle, nread, &buf, addr, flags);
     }
   }
   /* recv_cb callback may decide to pause or close the handle */


### PR DESCRIPTION
If the handle was opened using `uv_udp_open` ift's possible that the
kernel doesn't fill in the msg_name field, so return NULL as the address
in that case.

fixes #1252
