### PR TITLE
process: adjust quote_cmd_arg for empty arguments

### DIFF
--- a/src/win/process.c
+++ b/src/win/process.c
@@ -430,11 +430,10 @@ WCHAR* quote_cmd_arg(const WCHAR *source, WCHAR *target) {
   int quote_hit;
   WCHAR* start;
 
-  /*
-   * Check if the string must be quoted;
-   * if unnecessary, don't do it, it may only confuse older programs.
-   */
   if (len == 0) {
+    /* Need double quotation for empty argument */
+    *(target++) = L'"';
+    *(target++) = L'"';
     return target;
   }
 

--- a/test/test-spawn.c
+++ b/test/test-spawn.c
@@ -808,6 +808,7 @@ WCHAR* quote_cmd_arg(const WCHAR *source, WCHAR *target);
 
 TEST_IMPL(argument_escaping) {
   const WCHAR* test_str[] = {
+    L"",
     L"HelloWorld",
     L"Hello World",
     L"Hello\"World",


### PR DESCRIPTION
On Windows, `quote_cmd_arg` incorrectly handles "empty" command-line args, to the best of my knowledge.

If we use the scenario mentioned in joyent/node#7138, then it's true that the `lpCommandLine` param for `CreateProcessW` will be incorrectly formatted. Just to recap in this post, joyent/node#7138 says that if node calls `spawn(process.argv[0], ['foo', '', 'bar'])` then `quote_cmd_arg` will cause `lpCommandLine` for `CreateProcessW` to be `"node.exe foo  bar"`.

**Note the double spaces between `foo` and `bar`.**

In my tests, with a C# command-line argument, this extra space is stripped and the application only interprets 2 command-line args, even though we clearly want 3, from our node.js `spawn` call.

Now, in `quote_cmd_arg` the following check exists ...

```
  /*
   * Check if the string must be quoted;
   * if unnecessary, don't do it, it may only confuse older programs.
   */
  if (len == 0) {
    return target;
  }
```

I believe that this should be changed to actually insert an empty double quote, instead of skipped. Based on the comment, older programs may be confused, but C# programs are definitely broken. Also, whatever the OP in joyent/node#7138 was working with is broken - looks like another node app. It's completely valid on Windows to provide an empty command-line param, it just needs to be wrapped in quotes.
