### PR TITLE
unix, windows: remove unneeded define

### DIFF
--- a/include/uv-bsd.h
+++ b/include/uv-bsd.h
@@ -31,6 +31,4 @@
 
 #define UV_HAVE_KQUEUE 1
 
-#define UV_PLATFORM_HAS_IP6_LINK_LOCAL_ADDRESS
-
 #endif /* UV_BSD_H */

--- a/include/uv-darwin.h
+++ b/include/uv-darwin.h
@@ -58,6 +58,4 @@
 
 #define UV_HAVE_KQUEUE 1
 
-#define UV_PLATFORM_HAS_IP6_LINK_LOCAL_ADDRESS
-
 #endif /* UV_DARWIN_H */

--- a/include/uv-linux.h
+++ b/include/uv-linux.h
@@ -31,6 +31,4 @@
   void* watchers[2];                                                          \
   int wd;                                                                     \
 
-#define UV_PLATFORM_HAS_IP6_LINK_LOCAL_ADDRESS
-
 #endif /* UV_LINUX_H */

--- a/include/uv-sunos.h
+++ b/include/uv-sunos.h
@@ -41,6 +41,4 @@
 
 #endif /* defined(PORT_SOURCE_FILE) */
 
-#define UV_PLATFORM_HAS_IP6_LINK_LOCAL_ADDRESS
-
 #endif /* UV_SUNOS_H */

--- a/include/uv-win.h
+++ b/include/uv-win.h
@@ -587,4 +587,3 @@ int uv_utf16_to_utf8(const WCHAR* utf16Buffer, size_t utf16Size,
 int uv_utf8_to_utf16(const char* utf8Buffer, WCHAR* utf16Buffer,
     size_t utf16Size);
 
-#define UV_PLATFORM_HAS_IP6_LINK_LOCAL_ADDRESS

--- a/src/uv-common.c
+++ b/src/uv-common.c
@@ -35,7 +35,7 @@
 #include <stdlib.h> /* malloc */
 #include <string.h> /* memset */
 
-#if defined(UV_PLATFORM_HAS_IP6_LINK_LOCAL_ADDRESS) && !defined(_WIN32)
+#if !defined(_WIN32)
 # include <net/if.h> /* if_nametoindex */
 #endif
 
@@ -107,17 +107,14 @@ int uv_ip4_addr(const char* ip, int port, struct sockaddr_in* addr) {
 
 
 int uv_ip6_addr(const char* ip, int port, struct sockaddr_in6* addr) {
-#if defined(UV_PLATFORM_HAS_IP6_LINK_LOCAL_ADDRESS)
   char address_part[40];
   size_t address_part_size;
   const char* zone_index;
-#endif
 
   memset(addr, 0, sizeof(*addr));
   addr->sin6_family = AF_INET6;
   addr->sin6_port = htons(port);
 
-#if defined(UV_PLATFORM_HAS_IP6_LINK_LOCAL_ADDRESS)
   zone_index = strchr(ip, '%');
   if (zone_index != NULL) {
     address_part_size = zone_index - ip;
@@ -136,7 +133,6 @@ int uv_ip6_addr(const char* ip, int port, struct sockaddr_in6* addr) {
     addr->sin6_scope_id = if_nametoindex(zone_index);
 #endif
   }
-#endif
 
   return uv_inet_pton(AF_INET6, ip, &addr->sin6_addr);
 }

--- a/test/test-ip6-addr.c
+++ b/test/test-ip6-addr.c
@@ -32,7 +32,6 @@
 
 
 TEST_IMPL(ip6_addr_link_local) {
-#ifdef UV_PLATFORM_HAS_IP6_LINK_LOCAL_ADDRESS
   char string_address[INET6_ADDRSTRLEN];
   uv_interface_address_t* addresses;
   uv_interface_address_t* address;
@@ -93,9 +92,6 @@ TEST_IMPL(ip6_addr_link_local) {
 
   MAKE_VALGRIND_HAPPY();
   return 0;
-#else
-  RETURN_SKIP("Qualified link-local addresses are not supported.");
-#endif
 }
 
 


### PR DESCRIPTION
We define it for all supported platforms. I doubt there is a system which doesn't have `if_nametoindex`.

/cc @indutny
