### PR TITLE
windows: required environment variables

### DIFF
--- a/src/win/process.c
+++ b/src/win/process.c
@@ -25,6 +25,7 @@
 #include <stdlib.h>
 #include <signal.h>
 #include <limits.h>
+#include <malloc.h>
 
 #include "uv.h"
 #include "internal.h"

--- a/test/test-spawn.c
+++ b/test/test-spawn.c
@@ -897,11 +897,23 @@ TEST_IMPL(environment_creation) {
     "SYSTEM=ROOT", /* substring of a supplied var name */
     "SYSTEMROOTED=OMG", /* supplied var name is a substring */
     "TEMP=C:\\Temp",
+    "INVALID",
     "BAZ=QUX",
+    "B_Z=QUX",
+    "B\xe2\x82\xacZ=QUX",
+    "B\xf0\x90\x80\x82Z=QUX",
+    "B\xef\xbd\xa1Z=QUX",
+    "B\xf0\xa3\x91\x96Z=QUX",
+    "BAZ", /* repeat, invalid variable */
     NULL
   };
   WCHAR* wenvironment[] = {
     L"BAZ=QUX",
+    L"B_Z=QUX",
+    L"B\x20acZ=QUX",
+    L"B\xd800\xdc02Z=QUX",
+    L"B\xd84d\xdc56Z=QUX",
+    L"B\xff61Z=QUX",
     L"FOO=BAR",
     L"SYSTEM=ROOT", /* substring of a supplied var name */
     L"SYSTEMROOTED=OMG", /* supplied var name is a substring */
@@ -956,7 +968,7 @@ TEST_IMPL(environment_creation) {
 
   for (str = env, prev = NULL; *str; prev = str, str += wcslen(str) + 1) {
     int found = 0;
-    wprintf(L"%s\n", str);
+    _cputws(str); putchar('\n');
     for (i = 0; i < ARRAY_SIZE(wenvironment) && !found; i++) {
       if (!wcscmp(str, wenvironment[i])) {
         ASSERT(!found_in_loc_env[i]);
@@ -971,7 +983,7 @@ TEST_IMPL(environment_creation) {
         found = 1;
       }
     }
-    if (prev) { /* verify sort order */
+    if (prev) { /* verify sort order -- requires Vista */
       ASSERT(CompareStringOrdinal(prev, -1, str, -1, TRUE) == 1);
     }
     ASSERT(found); /* verify that we expected this variable */

--- a/test/test-spawn.c
+++ b/test/test-spawn.c
@@ -900,42 +900,90 @@ TEST_IMPL(environment_creation) {
     "BAZ=QUX",
     NULL
   };
-
-  WCHAR expected[512];
-  WCHAR* ptr = expected;
+  WCHAR* wenvironment[] = {
+    L"BAZ=QUX",
+    L"FOO=BAR",
+    L"SYSTEM=ROOT", /* substring of a supplied var name */
+    L"SYSTEMROOTED=OMG", /* supplied var name is a substring */
+    L"TEMP=C:\\Temp",
+  };
+  WCHAR* from_env[] = {
+    /* list should be kept in sync with list
+     * in process.c, minus variables in wenvironment */
+    L"HOMEDRIVE",
+    L"HOMEPATH",
+    L"LOGONSERVER",
+    L"PATH",
+    L"USERDOMAIN",
+    L"USERNAME",
+    L"USERPROFILE",
+    L"SYSTEMDRIVE",
+    L"SYSTEMROOT",
+    L"WINDIR",
+    /* test for behavior in the absence of a
+     * required-environment variable: */
+    L"ZTHIS_ENV_VARIABLE_DOES_NOT_EXIST", 
+  };
+  int found_in_loc_env[ARRAY_SIZE(wenvironment)] = {0};
+  int found_in_usr_env[ARRAY_SIZE(from_env)] = {0};
+  WCHAR *expected[ARRAY_SIZE(from_env)];
   int result;
   WCHAR* str;
+  WCHAR* prev;
   WCHAR* env;
 
-  for (i = 0; i < sizeof(environment) / sizeof(environment[0]) - 1; i++) {
-    ptr += uv_utf8_to_utf16(environment[i],
-                            ptr,
-                            expected + sizeof(expected) - ptr);
+  for (i = 0; i < ARRAY_SIZE(from_env); i++) {
+      /* copy expected additions to environment locally */
+      size_t len = GetEnvironmentVariableW(from_env[i], NULL, 0);
+      if (len == 0) {
+        found_in_usr_env[i] = 1;
+        str = (WCHAR*)malloc(1*sizeof(WCHAR));
+        *str = 0;
+        expected[i] = str;
+      } else {
+        size_t name_len = wcslen(from_env[i]);
+        str = (WCHAR*)malloc((name_len+1+len)*sizeof(WCHAR));
+        wmemcpy(str, from_env[i], name_len);
+        expected[i] = str;
+        str += name_len;
+        *str++ = L'=';
+        GetEnvironmentVariableW(from_env[i], str, len);
+     }
   }
-
-  memcpy(ptr, L"SYSTEMROOT=", sizeof(L"SYSTEMROOT="));
-  ptr += sizeof(L"SYSTEMROOT=")/sizeof(WCHAR) - 1;
-  ptr += GetEnvironmentVariableW(L"SYSTEMROOT",
-                                 ptr,
-                                 expected + sizeof(expected) - ptr);
-  ++ptr;
-
-  memcpy(ptr, L"SYSTEMDRIVE=", sizeof(L"SYSTEMDRIVE="));
-  ptr += sizeof(L"SYSTEMDRIVE=")/sizeof(WCHAR) - 1;
-  ptr += GetEnvironmentVariableW(L"SYSTEMDRIVE",
-                                 ptr,
-                                 expected + sizeof(expected) - ptr);
-  ++ptr;
-  *ptr = '\0';
 
   result = make_program_env(environment, &env);
   ASSERT(result == 0);
 
-  for (str = env; *str; str += wcslen(str) + 1) {
+  for (str = env, prev = NULL; *str; prev = str, str += wcslen(str) + 1) {
+    int found = 0;
     wprintf(L"%s\n", str);
+    for (i = 0; i < ARRAY_SIZE(wenvironment) && !found; i++) {
+      if (!wcscmp(str, wenvironment[i])) {
+        ASSERT(!found_in_loc_env[i]);
+        found_in_loc_env[i] = 1;
+        found = 1;
+      }
+    }
+    for (i = 0; i < ARRAY_SIZE(expected) && !found; i++) {
+      if (!wcscmp(str, expected[i])) {
+        ASSERT(!found_in_usr_env[i]);
+        found_in_usr_env[i] = 1;
+        found = 1;
+      }
+    }
+    if (prev) { /* verify sort order */
+      ASSERT(CompareStringOrdinal(prev, -1, str, -1, TRUE) == 1);
+    }
+    ASSERT(found); /* verify that we expected this variable */
   }
 
-  ASSERT(wcscmp(expected, env) == 0);
+  /* verify that we found all expected variables */
+  for (i = 0; i < ARRAY_SIZE(wenvironment); i++) {
+    ASSERT(found_in_loc_env[i]);
+  }
+  for (i = 0; i < ARRAY_SIZE(expected); i++) {
+    ASSERT(found_in_usr_env[i]);
+  }
 
   return 0;
 }


### PR DESCRIPTION
adds more of the undocumented-but-seemingly-required environment variables for uv_spawn

written to address https://github.com/JuliaLang/julia/issues/5574

this list was created with the help of https://github.com/Alexpux/Cygwin/blob/b266b04fbbd3a595f02ea149e4306d3ab9b1fe3d/winsup/cygwin/environ.cc#L955 to get a more complete list

I notice that cygwin file also ensures certain variables are uppercase for compatibility "for posix and backwards compatibility". Would you be interested in a pull request (written from scratch, but using the same variable list for reference) so that libuv also also does this? Or does this seem like a non-existent issue for libuv?
