### PR TITLE
unix: fix uv__open_cloexec usage

### DIFF
--- a/src/unix/async.c
+++ b/src/unix/async.c
@@ -231,7 +231,7 @@ int uv__async_start(uv_loop_t* loop, struct uv__async* wa, uv__async_cb cb) {
 
       snprintf(buf, sizeof(buf), "/proc/self/fd/%d", pipefd[0]);
       fd = uv__open_cloexec(buf, O_RDWR);
-      if (fd != -1) {
+      if (fd >= 0) {
         uv__close(pipefd[0]);
         uv__close(pipefd[1]);
         pipefd[0] = fd;

--- a/src/unix/stream.c
+++ b/src/unix/stream.c
@@ -444,6 +444,7 @@ void uv__stream_destroy(uv_stream_t* stream) {
  */
 static int uv__emfile_trick(uv_loop_t* loop, int accept_fd) {
   int err;
+  int emfile_fd;
 
   if (loop->emfile_fd == -1)
     return -EMFILE;
@@ -457,7 +458,10 @@ static int uv__emfile_trick(uv_loop_t* loop, int accept_fd) {
       uv__close(err);
   } while (err >= 0 || err == -EINTR);
 
-  SAVE_ERRNO(loop->emfile_fd = uv__open_cloexec("/", O_RDONLY));
+  emfile_fd = uv__open_cloexec("/", O_RDONLY);
+  if (emfile_fd >= 0)
+    loop->emfile_fd = emfile_fd;
+
   return err;
 }
 


### PR DESCRIPTION
It returns the fd or the negated errno.
