### PR TITLE
Fix build on mingw

### DIFF
--- a/include/uv-win.h
+++ b/include/uv-win.h
@@ -31,7 +31,7 @@ typedef intptr_t ssize_t;
 
 #include <winsock2.h>
 
-#if defined(__MINGW32__) && !defined(__MINGW64__)
+#if defined(__MINGW32__) && !defined(__MINGW64_VERSION_MAJOR)
 typedef struct pollfd {
   SOCKET fd;
   short  events;

--- a/include/uv-win.h
+++ b/include/uv-win.h
@@ -30,6 +30,15 @@ typedef intptr_t ssize_t;
 #endif
 
 #include <winsock2.h>
+
+#if defined(__MINGW32__) && !defined(__MINGW64__)
+typedef struct pollfd {
+  SOCKET fd;
+  short  events;
+  short  revents;
+} WSAPOLLFD, *PWSAPOLLFD, *LPWSAPOLLFD;
+#endif
+
 #include <mswsock.h>
 #include <ws2tcpip.h>
 #include <windows.h>

--- a/src/win/getnameinfo.c
+++ b/src/win/getnameinfo.c
@@ -27,6 +27,17 @@
 #include "internal.h"
 #include "req-inl.h"
 
+#ifndef GetNameInfo
+int WSAAPI GetNameInfoW(
+  const SOCKADDR *pSockaddr,
+  socklen_t SockaddrLength,
+  PWCHAR pNodeBuffer,
+  DWORD NodeBufferSize,
+  PWCHAR pServiceBuffer,
+  DWORD ServiceBufferSize,
+  INT Flags
+);
+#endif
 
 /* getnameinfo worker thread implementation */
 static DWORD WINAPI getnameinfo_thread_proc(void* parameter) {

--- a/src/win/tty.c
+++ b/src/win/tty.c
@@ -30,6 +30,10 @@
 # include <stdint.h>
 #endif
 
+#ifndef COMMON_LVB_REVERSE_VIDEO
+# define COMMON_LVB_REVERSE_VIDEO 0x4000
+#endif
+
 #include "uv.h"
 #include "internal.h"
 #include "handle-inl.h"


### PR DESCRIPTION
- add getnameinfo.c to Makefile.mingw
- define WSAPOLLFD on mingw
- call getnameinfo if GetNameInfo is not defined, and it out localized characters, so convert to wide characters.
- define COMMON_LVB_REVERSE_VIDEO if not defined
