### PR TITLE
Win mingw32 fixes (fix build on mingw32)

### DIFF
--- a/src/win/core.c
+++ b/src/win/core.c
@@ -26,9 +26,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#if !defined(__MINGW32__)
 #include <crtdbg.h>
-#endif
 
 #include "uv.h"
 #include "internal.h"
@@ -44,11 +42,11 @@ static uv_once_t uv_init_guard_ = UV_ONCE_INIT;
 static uv_once_t uv_default_loop_init_guard_ = UV_ONCE_INIT;
 
 
-#if defined(_DEBUG) && !defined(__MINGW32__)
+#if defined(_DEBUG)
 /* Our crt debug report handler allows us to temporarily disable asserts */
 /* just for the current thread. */
 
-__declspec( thread ) int uv__crt_assert_enabled = TRUE;
+UV_THREAD_LOCAL int uv__crt_assert_enabled = TRUE;
 
 static int uv__crt_dbg_report_handler(int report_type, char *message, int *ret_val) {
   if (uv__crt_assert_enabled || report_type != _CRT_ASSERT)

--- a/src/win/internal.h
+++ b/src/win/internal.h
@@ -31,13 +31,16 @@
 
 #ifdef _MSC_VER
 # define INLINE __inline
+# define UV_THREAD_LOCAL __declspec( thread )
 #else
 # define INLINE inline
+# define UV_THREAD_LOCAL __thread
 #endif
 
 
 #ifdef _DEBUG
-extern __declspec( thread ) int uv__crt_assert_enabled;
+
+extern UV_THREAD_LOCAL int uv__crt_assert_enabled;
 
 #define UV_BEGIN_DISABLE_CRT_ASSERT()                           \
   {                                                             \

--- a/uv.gyp
+++ b/uv.gyp
@@ -114,11 +114,11 @@
           ],
           'link_settings': {
             'libraries': [
-              '-ladvapi32.lib',
-              '-liphlpapi.lib',
-              '-lpsapi.lib',
-              '-lshell32.lib',
-              '-lws2_32.lib'
+              '-ladvapi32',
+              '-liphlpapi',
+              '-lpsapi',
+              '-lshell32',
+              '-lws2_32'
             ],
           },
         }, { # Not Windows i.e. POSIX
@@ -409,7 +409,7 @@
             'test/runner-win.c',
             'test/runner-win.h'
           ],
-          'libraries': [ 'ws2_32.lib' ]
+          'libraries': [ '-lws2_32' ]
         }, { # POSIX
           'defines': [ '_GNU_SOURCE' ],
           'sources': [
@@ -473,7 +473,7 @@
             'test/runner-win.c',
             'test/runner-win.h',
           ],
-          'libraries': [ 'ws2_32.lib' ]
+          'libraries': [ '-lws2_32' ]
         }, { # POSIX
           'defines': [ '_GNU_SOURCE' ],
           'sources': [


### PR DESCRIPTION
This fixes one issue with the gyp build using `.lib` in library names which AFAIK should not be necessary since gyp should be correcting the naming (can someone using the MS compiler check me on this?)

Also make threadlocal on GCC work and fix the CRT assert to make the debug build work.
