### PR TITLE
unix: define NI_MAXHOST and NI_MAXSERV if needed

### DIFF
--- a/include/uv-unix.h
+++ b/include/uv-unix.h
@@ -55,6 +55,14 @@
 # include "uv-bsd.h"
 #endif
 
+#ifndef NI_MAXHOST
+# define NI_MAXHOST 1025
+#endif
+
+#ifndef NI_MAXSERV
+# define NI_MAXSERV 32
+#endif
+
 #ifndef UV_IO_PRIVATE_PLATFORM_FIELDS
 # define UV_IO_PRIVATE_PLATFORM_FIELDS /* empty */
 #endif


### PR DESCRIPTION
OSX only exposes them if _POSIX_C_SOURCE is not defined, for instance.
