### PR TITLE
unix: use struct sockaddr_storage for target UDP addr

### DIFF
--- a/include/uv-unix.h
+++ b/include/uv-unix.h
@@ -213,7 +213,7 @@ typedef struct {
 
 #define UV_UDP_SEND_PRIVATE_FIELDS                                            \
   void* queue[2];                                                             \
-  struct sockaddr_in6 addr;                                                   \
+  struct sockaddr_storage addr;                                               \
   unsigned int nbufs;                                                         \
   uv_buf_t* bufs;                                                             \
   ssize_t status;                                                             \

--- a/src/unix/udp.c
+++ b/src/unix/udp.c
@@ -104,7 +104,7 @@ static void uv__udp_run_pending(uv_udp_t* handle) {
 
     memset(&h, 0, sizeof h);
     h.msg_name = &req->addr;
-    h.msg_namelen = (req->addr.sin6_family == AF_INET6 ?
+    h.msg_namelen = (req->addr.ss_family == AF_INET6 ?
       sizeof(struct sockaddr_in6) : sizeof(struct sockaddr_in));
     h.msg_iov = (struct iovec*) req->bufs;
     h.msg_iovlen = req->nbufs;


### PR DESCRIPTION
Quick review, @indutny ?
