### PR TITLE
unix: return UV_EAGAIN if uv_try_write cannot write any data

### DIFF
--- a/include/uv.h
+++ b/include/uv.h
@@ -707,8 +707,9 @@ UV_EXTERN int uv_write2(uv_write_t* req,
  * Same as `uv_write()`, but won't queue write request if it can't be completed
  * immediately.
  * Will return either:
- * - >= 0: number of bytes written (can be less than the supplied buffer size)
- * - < 0: negative error code
+ * - > 0: number of bytes written (can be less than the supplied buffer size)
+ * - < 0: negative error code (UV_EAGAIN is returned if no data can be sent
+ *   immediately)
  */
 UV_EXTERN int uv_try_write(uv_stream_t* handle,
                            const uv_buf_t bufs[],

--- a/src/unix/stream.c
+++ b/src/unix/stream.c
@@ -1374,7 +1374,7 @@ int uv_try_write(uv_stream_t* stream,
 
   /* Connecting or already writing some data */
   if (stream->connect_req != NULL || stream->write_queue_size != 0)
-    return 0;
+    return -EAGAIN;
 
   has_pollout = uv__io_active(&stream->io_watcher, UV__POLLOUT);
 
@@ -1404,7 +1404,10 @@ int uv_try_write(uv_stream_t* stream,
     uv__stream_osx_interrupt_select(stream);
   }
 
-  return (int) written;
+  if (written == 0)
+    return -EAGAIN;
+  else
+    return written;
 }
 
 

--- a/test/test-tcp-try-write.c
+++ b/test/test-tcp-try-write.c
@@ -63,12 +63,14 @@ static void connect_cb(uv_connect_t* req, int status) {
   do {
     buf = uv_buf_init(zeroes, sizeof(zeroes));
     r = uv_try_write((uv_stream_t*) &client, &buf, 1);
-    ASSERT(r >= 0);
-    bytes_written += r;
+    ASSERT(r > 0 || r == UV_EAGAIN);
+    if (r > 0) {
+      bytes_written += r;
 
-    /* Partial write */
-    if (r != (int) sizeof(zeroes))
-      break;
+      /* Partial write */
+      if (r != (int) sizeof(zeroes))
+        break;
+    }
   } while (1);
   uv_close((uv_handle_t*) &client, close_cb);
 }


### PR DESCRIPTION
For consistency with `uv_udp_try_send`.

Yes, UDP and TCP are different but I think it reasonable to think users will expect the same behavior on both cases. The reason why we return EAGAIN on UDP is bbecause sending an empty datagram is allowed, so we need to know if what happened is that the datagram could not be sent vs an empty datagram was sent. We cannot send an empty TCP packet, but still IMHO consistent behavior is a Good Thing (TM) in this case.

/cc @indutny

@txdv come and agree with me here :-)
