### PR TITLE
unix: fix inconsistent code style

### DIFF
--- a/src/unix/tcp.c
+++ b/src/unix/tcp.c
@@ -289,7 +289,7 @@ int uv_tcp_keepalive(uv_tcp_t* handle, int on, unsigned int delay) {
   int err;
 
   if (uv__stream_fd(handle) != -1) {
-    err =uv__tcp_keepalive(uv__stream_fd(handle), on, delay);
+    err = uv__tcp_keepalive(uv__stream_fd(handle), on, delay);
     if (err)
       return err;
   }


### PR DESCRIPTION
Fixed a line in `unix/tcp.c` that does not follow the style with rest of the project. 
