### PR TITLE
Proposal: Re-add travis configuration and badge

### DIFF
--- a/.ci/build-test.sh
+++ b/.ci/build-test.sh
@@ -1,0 +1,5 @@
+export CFLAGS="$CFLAGS -DDISABLE_NONDETERMINISTIC_TESTS"
+sh autogen.sh
+./configure
+make
+make check

--- a/.ci/build-test.sh
+++ b/.ci/build-test.sh
@@ -1,5 +1,5 @@
 export CFLAGS="$CFLAGS -DDISABLE_NONDETERMINISTIC_TESTS"
 sh autogen.sh
-./configure
+./configure $CI_CONFIGURE_OPTS
 make
 make check

--- a/.ci/ubuntu-12.04-x64.sh
+++ b/.ci/ubuntu-12.04-x64.sh
@@ -1,0 +1,1 @@
+. "$CI_ROOT/build-test.sh"

--- a/.ci/ubuntu-12.04-x86.sh
+++ b/.ci/ubuntu-12.04-x86.sh
@@ -1,0 +1,9 @@
+# Pins the version of the java package installed on the Travis VMs
+# and avoids a lengthy upgrade process for them.
+sudo apt-mark hold oracle-java7-installer oracle-java8-installer
+sudo apt-get update
+sudo apt-get install libc6-dev:i386 gcc-multilib
+export CFLAGS=-m32
+export LDFLAGS=-m32
+export CI_CONFIGURE_OPTS=--host=i386-pc-linux-gnu
+. "$CI_ROOT/build-test.sh"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,9 @@
+language: c
+env:
+  global:
+    - PROJECT_ROOT="$(pwd)"
+    - CI_ROOT="$PROJECT_ROOT/.ci"
+  matrix:
+    - TARGET=ubuntu-12.04-x64
+script:
+  - sh "${CI_ROOT}/${TARGET}.sh"

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,5 +5,6 @@ env:
     - CI_ROOT="$PROJECT_ROOT/.ci"
   matrix:
     - TARGET=ubuntu-12.04-x64
+    - TARGET=ubuntu-12.04-x86
 script:
   - sh "${CI_ROOT}/${TARGET}.sh"

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 ![libuv][libuv_banner]
+[![Build Status](https://travis-ci.org/joyent/libuv.svg?branch=master)](https://travis-ci.org/joyent/libuv)
 
 ## Overview
 

--- a/test/test-list.h
+++ b/test/test-list.h
@@ -54,7 +54,9 @@ TEST_DECLARE   (tcp_ping_pong_v6)
 TEST_DECLARE   (pipe_ping_pong)
 TEST_DECLARE   (delayed_accept)
 TEST_DECLARE   (multiple_listen)
+#ifndef DISABLE_NONDETERMINISTIC_TESTS
 TEST_DECLARE   (tcp_writealot)
+#endif
 TEST_DECLARE   (tcp_try_write)
 TEST_DECLARE   (tcp_write_queue_order)
 TEST_DECLARE   (tcp_open)
@@ -328,8 +330,10 @@ TASK_LIST_START
   TEST_ENTRY  (delayed_accept)
   TEST_ENTRY  (multiple_listen)
 
+#ifndef DISABLE_NONDETERMINISTIC_TESTS
   TEST_ENTRY  (tcp_writealot)
   TEST_HELPER (tcp_writealot, tcp4_echo_server)
+#endif
 
   TEST_ENTRY  (tcp_try_write)
 


### PR DESCRIPTION
CI configuration was removed in @cf1dc613177 due to nondeterminism caused by travis. This PR introduces the `DISABLE_NONDETERMINISTIC_TESTS` ifndef guard to disable tests that may be affected by nondeterminism in the test environment.

Running the tests in a local ubuntu 12.04 virtualbox, I managed to get some random tests failures in the `tcp_writealot` test. The failures became frequent after a while and persisted even across reboots! It seems the operating system is saving some kind of state related to the network stack that is causing this problem.

I'm not sure what tests were randomly failing before, but for now I only wrapped `tcp_writealot` in the ifndef guard.

If this PR is accepted, I will send another that uses mingw/wine to cross-compile/test for windows. This pattern can be extended to other supported platforms through the use of prebuilt virtual machines and qemu
