### PR TITLE
windows: relay TCP bind errors via ipc

### DIFF
--- a/include/uv-win.h
+++ b/include/uv-win.h
@@ -409,7 +409,7 @@ RB_HEAD(uv_timer_tree_s, uv_timer_s);
 
 #define UV_TCP_PRIVATE_FIELDS                                                 \
   SOCKET socket;                                                              \
-  int bind_error;                                                             \
+  int delayed_error;                                                          \
   union {                                                                     \
     struct { uv_tcp_server_fields };                                          \
     struct { uv_tcp_connection_fields };                                      \

--- a/src/win/internal.h
+++ b/src/win/internal.h
@@ -75,7 +75,6 @@ extern UV_THREAD_LOCAL int uv__crt_assert_enabled;
 /* Used by streams and UDP handles. */
 #define UV_HANDLE_READING                       0x00000100
 #define UV_HANDLE_BOUND                         0x00000200
-#define UV_HANDLE_BIND_ERROR                    0x00000400
 #define UV_HANDLE_LISTENING                     0x00000800
 #define UV_HANDLE_CONNECTION                    0x00001000
 #define UV_HANDLE_CONNECTED                     0x00002000
@@ -125,6 +124,12 @@ extern UV_THREAD_LOCAL int uv__crt_assert_enabled;
 /*
  * TCP
  */
+
+typedef struct {
+  WSAPROTOCOL_INFOW socket_info;
+  int delayed_error;
+} uv__ipc_socket_info_ex;
+
 int uv_tcp_listen(uv_tcp_t* handle, int backlog, uv_connection_cb cb);
 int uv_tcp_accept(uv_tcp_t* server, uv_tcp_t* client);
 int uv_tcp_read_start(uv_tcp_t* handle, uv_alloc_cb alloc_cb,
@@ -143,7 +148,7 @@ void uv_process_tcp_connect_req(uv_loop_t* loop, uv_tcp_t* handle,
 void uv_tcp_close(uv_loop_t* loop, uv_tcp_t* tcp);
 void uv_tcp_endgame(uv_loop_t* loop, uv_tcp_t* handle);
 
-int uv_tcp_import(uv_tcp_t* tcp, WSAPROTOCOL_INFOW* socket_protocol_info,
+int uv_tcp_import(uv_tcp_t* tcp, uv__ipc_socket_info_ex* socket_info_ex,
     int tcp_connection);
 
 int uv_tcp_duplicate_socket(uv_tcp_t* handle, int pid,

--- a/src/win/tcp.c
+++ b/src/win/tcp.c
@@ -156,6 +156,7 @@ int uv_tcp_init(uv_loop_t* loop, uv_tcp_t* handle) {
   handle->func_acceptex = NULL;
   handle->func_connectex = NULL;
   handle->processed_accepts = 0;
+  handle->delayed_error = 0;
 
   return 0;
 }
@@ -302,8 +303,7 @@ static int uv_tcp_try_bind(uv_tcp_t* handle,
     err = WSAGetLastError();
     if (err == WSAEADDRINUSE) {
       /* Some errors are not to be reported until connect() or listen() */
-      handle->bind_error = err;
-      handle->flags |= UV_HANDLE_BIND_ERROR;
+      handle->delayed_error = err;
     } else {
       return err;
     }
@@ -528,8 +528,8 @@ int uv_tcp_listen(uv_tcp_t* handle, int backlog, uv_connection_cb cb) {
     return WSAEISCONN;
   }
 
-  if (handle->flags & UV_HANDLE_BIND_ERROR) {
-    return handle->bind_error;
+  if (handle->delayed_error) {
+    return handle->delayed_error;
   }
 
   if (!(handle->flags & UV_HANDLE_BOUND)) {
@@ -539,8 +539,8 @@ int uv_tcp_listen(uv_tcp_t* handle, int backlog, uv_connection_cb cb) {
                           0);
     if (err)
       return err;
-    if (handle->flags & UV_HANDLE_BIND_ERROR)
-      return handle->bind_error;
+    if (handle->delayed_error)
+      return handle->delayed_error;
   }
 
   if (!handle->func_acceptex) {
@@ -712,8 +712,8 @@ static int uv_tcp_try_connect(uv_connect_t* req,
   DWORD bytes;
   int err;
 
-  if (handle->flags & UV_HANDLE_BIND_ERROR) {
-    return handle->bind_error;
+  if (handle->delayed_error) {
+    return handle->delayed_error;
   }
 
   if (!(handle->flags & UV_HANDLE_BOUND)) {
@@ -727,8 +727,8 @@ static int uv_tcp_try_connect(uv_connect_t* req,
     err = uv_tcp_try_bind(handle, bind_addr, addrlen, 0);
     if (err)
       return err;
-    if (handle->flags & UV_HANDLE_BIND_ERROR)
-      return handle->bind_error;
+    if (handle->delayed_error)
+      return handle->delayed_error;
   }
 
   if (!handle->func_connectex) {
@@ -777,8 +777,8 @@ int uv_tcp_getsockname(const uv_tcp_t* handle,
     return UV_EINVAL;
   }
 
-  if (handle->flags & UV_HANDLE_BIND_ERROR) {
-    return uv_translate_sys_error(handle->bind_error);
+  if (handle->delayed_error) {
+    return uv_translate_sys_error(handle->delayed_error);
   }
 
   result = getsockname(handle->socket, name, namelen);
@@ -799,8 +799,8 @@ int uv_tcp_getpeername(const uv_tcp_t* handle,
     return UV_EINVAL;
   }
 
-  if (handle->flags & UV_HANDLE_BIND_ERROR) {
-    return uv_translate_sys_error(handle->bind_error);
+  if (handle->delayed_error) {
+    return uv_translate_sys_error(handle->delayed_error);
   }
 
   result = getpeername(handle->socket, name, namelen);
@@ -1117,14 +1117,13 @@ void uv_process_tcp_connect_req(uv_loop_t* loop, uv_tcp_t* handle,
 }
 
 
-int uv_tcp_import(uv_tcp_t* tcp, WSAPROTOCOL_INFOW* socket_protocol_info,
+int uv_tcp_import(uv_tcp_t* tcp, uv__ipc_socket_info_ex* socket_info_ex,
     int tcp_connection) {
   int err;
-
   SOCKET socket = WSASocketW(FROM_PROTOCOL_INFO,
                              FROM_PROTOCOL_INFO,
                              FROM_PROTOCOL_INFO,
-                             socket_protocol_info,
+                             &socket_info_ex->socket_info,
                              0,
                              WSA_FLAG_OVERLAPPED);
 
@@ -1141,7 +1140,7 @@ int uv_tcp_import(uv_tcp_t* tcp, WSAPROTOCOL_INFOW* socket_protocol_info,
   err = uv_tcp_set_socket(tcp->loop,
                           tcp,
                           socket,
-                          socket_protocol_info->iAddressFamily,
+                          socket_info_ex->socket_info.iAddressFamily,
                           1);
   if (err) {
     closesocket(socket);
@@ -1155,6 +1154,8 @@ int uv_tcp_import(uv_tcp_t* tcp, WSAPROTOCOL_INFOW* socket_protocol_info,
 
   tcp->flags |= UV_HANDLE_BOUND;
   tcp->flags |= UV_HANDLE_SHARED_TCP_SOCKET;
+
+  tcp->delayed_error = socket_info_ex->delayed_error;
 
   tcp->loop->active_tcp_streams++;
   return 0;
@@ -1216,13 +1217,10 @@ int uv_tcp_duplicate_socket(uv_tcp_t* handle, int pid,
         return ERROR_INVALID_PARAMETER;
       }
 
-      /* Report any deferred bind errors now. */
-      if (handle->flags & UV_HANDLE_BIND_ERROR) {
-        return handle->bind_error;
-      }
-
-      if (listen(handle->socket, SOMAXCONN) == SOCKET_ERROR) {
-        return WSAGetLastError();
+      if (!(handle->delayed_error)) {
+        if (listen(handle->socket, SOMAXCONN) == SOCKET_ERROR) {
+          handle->delayed_error = WSAGetLastError();
+        }
       }
     }
   }

--- a/test/run-tests.c
+++ b/test/run-tests.c
@@ -39,6 +39,7 @@
 int ipc_helper(int listen_after_write);
 int ipc_helper_tcp_connection(void);
 int ipc_send_recv_helper(void);
+int ipc_helper_bind_twice(void);
 int stdio_over_pipes_helper(void);
 
 static int maybe_run_test(int argc, char **argv);
@@ -80,6 +81,10 @@ static int maybe_run_test(int argc, char **argv) {
 
   if (strcmp(argv[1], "ipc_helper_tcp_connection") == 0) {
     return ipc_helper_tcp_connection();
+  }
+
+  if (strcmp(argv[1], "ipc_helper_bind_twice") == 0) {
+    return ipc_helper_bind_twice();
   }
 
   if (strcmp(argv[1], "stdio_over_pipes_helper") == 0) {

--- a/test/test-list.h
+++ b/test/test-list.h
@@ -258,6 +258,7 @@ TEST_DECLARE   (listen_with_simultaneous_accepts)
 TEST_DECLARE   (listen_no_simultaneous_accepts)
 TEST_DECLARE   (fs_stat_root)
 TEST_DECLARE   (spawn_with_an_odd_path)
+TEST_DECLARE   (ipc_listen_after_bind_twice)
 #else
 TEST_DECLARE   (emfile)
 TEST_DECLARE   (close_fd)
@@ -526,6 +527,7 @@ TASK_LIST_START
   TEST_ENTRY  (listen_no_simultaneous_accepts)
   TEST_ENTRY  (fs_stat_root)
   TEST_ENTRY  (spawn_with_an_odd_path)
+  TEST_ENTRY  (ipc_listen_after_bind_twice)
 #else
   TEST_ENTRY  (emfile)
   TEST_ENTRY  (close_fd)


### PR DESCRIPTION
This is the libuv side of the fix for Node's cluster module on Windows.
https://github.com/joyent/node/issues/7691

Windows and Unix return certain socket errors (i.e. EADDRINUSE) at
different times: bind on Windows, and listen on Unix.
In an effort to hide this difference, libuv on Windows stores such
errors in the bind_error field of uv_tcp_t, to defer raising it at
listen time.
This worked fine except for the case in which a socket is shared in
a Node cluster and a bind error occurs.

A previous attempt to fix this (
https://github.com/joyent/libuv/commit/d1e6be1460f555a1f8a4063d7642696aa7238769
https://github.com/joyent/node/commit/3da36fe00e5d85414031ae812e473f16629d8645
) was flawed becaused in an attempt to relay the error at the JS level
it caused the master to start accepting connections.

With this new approach, libuv itself is relaying the bind errors,
providing for a uniform behavior of uv_tcp_listen.
