### PR TITLE
include: avoid using C++ 'template' reserved word (fixes #1394)

### DIFF
--- a/include/uv.h
+++ b/include/uv.h
@@ -1892,7 +1892,7 @@ UV_EXTERN int uv_fs_write(uv_loop_t* loop, uv_fs_t* req, uv_file file,
 UV_EXTERN int uv_fs_mkdir(uv_loop_t* loop, uv_fs_t* req, const char* path,
     int mode, uv_fs_cb cb);
 
-UV_EXTERN int uv_fs_mkdtemp(uv_loop_t* loop, uv_fs_t* req, const char* template,
+UV_EXTERN int uv_fs_mkdtemp(uv_loop_t* loop, uv_fs_t* req, const char* tpl,
     uv_fs_cb cb);
 
 UV_EXTERN int uv_fs_rmdir(uv_loop_t* loop, uv_fs_t* req, const char* path,

--- a/src/unix/fs.c
+++ b/src/unix/fs.c
@@ -1009,10 +1009,10 @@ int uv_fs_mkdir(uv_loop_t* loop,
 
 int uv_fs_mkdtemp(uv_loop_t* loop,
                   uv_fs_t* req,
-                  const char* template,
+                  const char* tpl,
                   uv_fs_cb cb) {
   INIT(MKDTEMP);
-  req->path = strdup(template);
+  req->path = strdup(tpl);
   if (req->path == NULL)
     return -ENOMEM;
   POST;

--- a/src/win/fs.c
+++ b/src/win/fs.c
@@ -1797,13 +1797,13 @@ int uv_fs_mkdir(uv_loop_t* loop, uv_fs_t* req, const char* path, int mode,
 }
 
 
-int uv_fs_mkdtemp(uv_loop_t* loop, uv_fs_t* req, const char* template,
+int uv_fs_mkdtemp(uv_loop_t* loop, uv_fs_t* req, const char* tpl,
     uv_fs_cb cb) {
   int err;
 
   uv_fs_req_init(loop, req, UV_FS_MKDTEMP, cb);
 
-  err = fs__capture_path(loop, req, template, NULL, TRUE);
+  err = fs__capture_path(loop, req, tpl, NULL, TRUE);
   if (err)
     return uv_translate_sys_error(err);
 


### PR DESCRIPTION
'template' is a reserved keywork in C++, so including uv.h into a C++ file would fail to compile. This pull request fixes that.
