### PR TITLE
Use OpenBSD implementation for uv_fs_mkdtemp on Windows

### DIFF
--- a/include/uv.h
+++ b/include/uv.h
@@ -1892,6 +1892,14 @@ UV_EXTERN int uv_fs_write(uv_loop_t* loop, uv_fs_t* req, uv_file file,
 UV_EXTERN int uv_fs_mkdir(uv_loop_t* loop, uv_fs_t* req, const char* path,
     int mode, uv_fs_cb cb);
 
+/*
+ * Generates a uniquely named temporary directory from tpl. The last six
+ * characters of tpl must be XXXXXX and these are replaced with a string that
+ * makes the directory name unique. On success the name of created directory
+ * will be stored in req->path.
+ * You should ensure that srand() has been called before using this function
+ * on Windows.
+ */
 UV_EXTERN int uv_fs_mkdtemp(uv_loop_t* loop, uv_fs_t* req, const char* tpl,
     uv_fs_cb cb);
 

--- a/include/uv.h
+++ b/include/uv.h
@@ -1897,8 +1897,6 @@ UV_EXTERN int uv_fs_mkdir(uv_loop_t* loop, uv_fs_t* req, const char* path,
  * characters of tpl must be XXXXXX and these are replaced with a string that
  * makes the directory name unique. On success the name of created directory
  * will be stored in req->path.
- * You should ensure that srand() has been called before using this function
- * on Windows.
  */
 UV_EXTERN int uv_fs_mkdtemp(uv_loop_t* loop, uv_fs_t* req, const char* tpl,
     uv_fs_cb cb);


### PR DESCRIPTION
As [stated](https://github.com/joyent/libuv/pull/1368/files#r15906993) by @sam-github libuv can't use glibc's modified code because glibc licensed under LGPL, but libuv under MIT. I apologize again, it was my fault because of ignorance.
So in this PR I ported [OpenBSD version](http://openbsd.cs.toronto.edu/cgi-bin/cvsweb/src/lib/libc/stdio/mktemp.c?rev=1.33&content-type=text/x-cvsweb-markup).
Main differences with original:
- `tries = TMP_MAX` instead of `tries = INT_MAX`. Though I'm not sure what is the best value.
- Used `rand` instead of `arc4random`. Though I found [portable arc4random.c](https://github.com/libevent/libevent/blob/master/arc4random.c) licensed under 3-clause BSD license. So it is possible to use it if appropriate.
