### PR TITLE
unix: fix typedef of uv_buf_t

### DIFF
--- a/include/uv-unix.h
+++ b/include/uv-unix.h
@@ -117,7 +117,7 @@ struct uv__async {
 #endif
 
 /* Note: May be cast to struct iovec. See writev(2). */
-typedef struct {
+typedef struct uv_buf_t {
   char* base;
   size_t len;
 } uv_buf_t;


### PR DESCRIPTION
Typedefs of unnamed structs cannot be forward declared.
Giving the uv_buf_t struct a name makes forward declarations possible.
As a side note: The uv_buf_t struct already got a name in uv-win.h.
