### PR TITLE
Add the throw_safe variable to the uv_fs_s struct

### DIFF
--- a/include/uv.h
+++ b/include/uv.h
@@ -1906,6 +1906,7 @@ struct uv_fs_s {
   uv_fs_type fs_type;
   uv_loop_t* loop;
   uv_fs_cb cb;
+  int throw_safe;
   ssize_t result;
   void* ptr;
   const char* path;


### PR DESCRIPTION
This variable is meant to control whether IO errors are created or not.
This enables: https://github.com/joyent/node/pull/8189/

The general idea is to throw less errors that are immediately caught.
This throw and catch behaviour is present in the module.js and can 
significantly slow down the require calls (especially in case of coffeescript).
