### PR TITLE
windows: ensure fs_event always provides filename

### DIFF
--- a/src/win/fs-event.c
+++ b/src/win/fs-event.c
@@ -369,7 +369,8 @@ void uv_process_fs_event_req(uv_loop_t* loop, uv_req_t* req,
             /*
              * We attempt to convert the file name to its long form for
              * events that still point to valid files on disk.
-             * For removed and renamed events, we do not provide the file name.
+             * For removed and renamed from events, we do not provide the
+             * long file name.
              */
             if (file_info->Action != FILE_ACTION_REMOVED &&
               file_info->Action != FILE_ACTION_RENAMED_OLD_NAME) {
@@ -420,18 +421,15 @@ void uv_process_fs_event_req(uv_loop_t* loop, uv_req_t* req,
                   long_filenamew = NULL;
                 }
               }
+            }
 
-              /*
-               * If we couldn't get the long name - just use the name
-               * provided by ReadDirectoryChangesW.
-               */
-              if (!long_filenamew) {
-                filenamew = file_info->FileName;
-                sizew = file_info->FileNameLength / sizeof(WCHAR);
-              }
-            } else {
-              /* Removed or renamed callbacks don't provide filename. */
-              filenamew = NULL;
+            /*
+             * If we couldn't get the long name - just use the name
+             * provided by ReadDirectoryChangesW.
+             */
+            if (!long_filenamew) {
+              filenamew = file_info->FileName;
+              sizew = file_info->FileNameLength / sizeof(WCHAR);
             }
           } else {
             /* We already have the long name of the file, so just use it. */


### PR DESCRIPTION
`uv_fs_event` didn't provide filename argument on Windows when a file is deleted or renamed, although it does on Linux.

Fix this by ensuring that fs_event always provides filename argument on Windows.

---

Node.js API document says:

> Providing `filename` argument in the callback is not supported on every platform (currently it's only supported on Linux and Windows). Even on supported platforms `filename` is not always guaranteed to be provided.
> 
> http://nodejs.org/docs/latest/api/fs.html#fs_filename_argument

But, it's better that we provide `filename` argument if we can, isn't it?
# How to reproduce this bug

Use following script:

``` javascript
var fs = require('fs');

var monitor = fs.watch('./', function(changes, fn) {
  console.log("%s :  %s", changes, fn);
});

fs.writeFileSync('foo.txt', 'new contents');
fs.renameSync('foo.txt', 'bar.txt');
fs.unlinkSync('bar.txt');

setTimeout(function() {
  monitor.close();
}, 1000);
```
## Linux

On CentOS 6.4 x64 (Node.js v0.10.29)

``` console
$ node test.js
rename :  foo.txt  # writeFile
change :  foo.txt  # writeFile
rename :  foo.txt  # rename (src)
rename :  bar.txt  # rename (dst)
rename :  bar.txt  # unlink
```

On Windows 8.1 x64 (Node.j v0.10.21)

``` console
> node test.js
rename :  foo.txt  # writeFile
change :  foo.txt  # writeFile
rename :  null     # rename (src) <--- FIX THIS
rename :  bar.txt  # rename (dst)
rename :  null     # unlink       <--- FIX THIS
```
