### PR TITLE
build: use same CFLAGS in autotools build as in gyp

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -81,6 +81,7 @@ else  # WINNT
 
 include_HEADERS += include/uv-unix.h
 AM_CPPFLAGS += -I$(top_srcdir)/src/unix
+libuv_la_CFLAGS += -g --std=gnu89 -pedantic -Wall -Wextra -Wno-unused-parameter
 libuv_la_SOURCES += src/unix/async.c \
                    src/unix/atomic-ops.h \
                    src/unix/core.c \


### PR DESCRIPTION
Closes #1362
