### PR TITLE
Implement uv_sanitize_signal_handling().

### DIFF
--- a/src/win/core.c
+++ b/src/win/core.c
@@ -456,3 +456,6 @@ int uv__socket_sockopt(uv_handle_t* handle, int optname, int* value) {
 
   return 0;
 }
+
+void uv_sanitize_signal_handling(void) {
+}


### PR DESCRIPTION
On Unix, this function allows an application to set up a safe
environment with respect to signal handling, ensuring that random system
calls don't fail with EINTR.

See: https://github.com/saghul/pyuv/issues/173 but ignore the misguided attempt to use signalfd.

The reason why I like this solution is that it is very general. It provides assurance that there isn't some obscure code lying around that will fail due to EINTR once in a blue moon. I am personally not interested in solutions which don't solve the problem in general.

This function is optional to use and its presence is not invasive. Its behavior is documented exactly so the programmer has a chance to see if using it is the right thing for their application. Even though it is quite simple and the programmer might as well do these things directly, having it here provides awareness of the solution and a reference implementation.
