### PR TITLE
unix: Prefer UV_EADDRINFO to UV_UNKNOWN as uv_getaddrinfo error code

### DIFF
--- a/src/unix/getaddrinfo.c
+++ b/src/unix/getaddrinfo.c
@@ -72,6 +72,8 @@ static void uv__getaddrinfo_done(struct uv__work* w, int status) {
   if (req->retcode < 0) {
     /* EAI_SYSTEM error */
     uv__set_sys_error(req->loop, -req->retcode);
+    if (req->loop->last_err.code == UV_UNKNOWN)
+      req->loop->last_err.code = UV_EADDRINFO;
   } else if (req->retcode == 0) {
     /* OK */
 #if defined(EAI_NODATA) /* FreeBSD deprecated EAI_NODATA */


### PR DESCRIPTION
Commit dd893814a assumes that errno will always be successfully interpreted
by uv__set_sys_error, but in some cases loop->last_err.code now gets set to
UV_UNKNOWN.
In such cases, this change restores the previous default code, UV_EADDRINFO.
