### PR TITLE
Fix windows build

### DIFF
--- a/include/uv-win.h
+++ b/include/uv-win.h
@@ -472,7 +472,6 @@ RB_HEAD(uv_timer_tree_s, uv_timer_s);
   uv_write_t* non_overlapped_writes_tail;                                     \
   uv_mutex_t readfile_mutex;                                                  \
   volatile HANDLE readfile_thread;                                            \
-  void* reserved;
 
 #define UV_PIPE_PRIVATE_FIELDS                                                \
   HANDLE handle;                                                              \


### PR DESCRIPTION
```
cc -Wall -Wextra -Wno-unused-parameter -Iinclude -Isrc -Isrc/win -DWIN32_LEAN_AND_MEAN -D_WIN32_WINNT=0x0600 -c -o src/fs-poll.o src/fs-poll.c
In file included from include/uv.h:59:0,
                 from src/fs-poll.c:22:
include/uv-win.h:475:9: error: duplicate member 'reserved'
   void* reserved;
         ^
include/uv-win.h:482:14: note: in expansion of macro 'uv_pipe_connection_fields'

     struct { uv_pipe_connection_fields };                                     \

              ^
include/uv.h:1225:3: note: in expansion of macro 'UV_PIPE_PRIVATE_FIELDS'
   UV_PIPE_PRIVATE_FIELDS
   ^
Makefile.mingw:84: recipe for target 'src/fs-poll.o' failed
mingw32-make: *** [src/fs-poll.o] Error 1
```
