### PR TITLE
windows: further simplify the code for timers

### DIFF
--- a/src/win/internal.h
+++ b/src/win/internal.h
@@ -65,7 +65,6 @@ extern UV_THREAD_LOCAL int uv__crt_assert_enabled;
 /* Used by all handles. */
 #define UV_HANDLE_CLOSED                        0x00000002
 #define UV_HANDLE_ENDGAME_QUEUED                0x00000004
-#define UV_HANDLE_ACTIVE                        0x00000010
 
 /* uv-common.h: #define UV__HANDLE_CLOSING      0x00000001 */
 /* uv-common.h: #define UV__HANDLE_ACTIVE       0x00000040 */

--- a/src/win/loop-watcher.c
+++ b/src/win/loop-watcher.c
@@ -49,7 +49,7 @@ void uv_loop_watcher_endgame(uv_loop_t* loop, uv_handle_t* handle) {
                                                                               \
     assert(handle->type == UV_##NAME);                                        \
                                                                               \
-    if (handle->flags & UV_HANDLE_ACTIVE)                                     \
+    if (uv__is_active(handle))                                                \
       return 0;                                                               \
                                                                               \
     if (cb == NULL)                                                           \
@@ -67,7 +67,6 @@ void uv_loop_watcher_endgame(uv_loop_t* loop, uv_handle_t* handle) {
     loop->name##_handles = handle;                                            \
                                                                               \
     handle->name##_cb = cb;                                                   \
-    handle->flags |= UV_HANDLE_ACTIVE;                                        \
     uv__handle_start(handle);                                                 \
                                                                               \
     return 0;                                                                 \
@@ -79,7 +78,7 @@ void uv_loop_watcher_endgame(uv_loop_t* loop, uv_handle_t* handle) {
                                                                               \
     assert(handle->type == UV_##NAME);                                        \
                                                                               \
-    if (!(handle->flags & UV_HANDLE_ACTIVE))                                  \
+    if (!uv__is_active(handle))                                               \
       return 0;                                                               \
                                                                               \
     /* Update loop head if needed */                                          \
@@ -99,7 +98,6 @@ void uv_loop_watcher_endgame(uv_loop_t* loop, uv_handle_t* handle) {
       handle->name##_next->name##_prev = handle->name##_prev;                 \
     }                                                                         \
                                                                               \
-    handle->flags &= ~UV_HANDLE_ACTIVE;                                       \
     uv__handle_stop(handle);                                                  \
                                                                               \
     return 0;                                                                 \


### PR DESCRIPTION
- Remove the UV_HANDLE_ACTIVE flag. It's a duplicate from
  UV__HANDLE_ACTIVE, which was used solely on timers and loop watchers.
- Avoid duplicated code when running timers by stopping the handle and
  rearming it with the repeat time, thus having a single place where the
  timers are added and removed to and from the RB tree, respectively.
