### PR TITLE
Add missing test data files with EXTRA_DIST

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -106,6 +106,8 @@ libuv_la_SOURCES += src/unix/async.c \
 
 endif  # WINNT
 
+EXTRA_DIST = test/fixtures/empty_file \
+             test/fixtures/load_error.node 
 TESTS = test/run-tests
 check_PROGRAMS = test/run-tests
 test_run_tests_CFLAGS =


### PR DESCRIPTION
Ensures that tests pass from a dist tarball.

Run make dist, then untar the resulting file.  Running make check will fail because of missing test data files.  With this patch, things will work again.  Hooray!
