### PR TITLE
doc: update references to current stable branch

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,10 +37,10 @@ Okay, so you have decided on the proper branch.  Create a feature branch
 and start hacking:
 
 ```
-$ git checkout -b my-feature-branch -t origin/v0.10
+$ git checkout -b my-feature-branch -t origin/v1.x
 ```
 
-(Where v0.10 is the latest stable branch as of this writing.)
+(Where v1.x is the latest stable branch as of this writing.)
 
 ### CODE
 
@@ -131,7 +131,7 @@ Use `git rebase` (not `git merge`) to sync your work from time to time.
 
 ```
 $ git fetch upstream
-$ git rebase upstream/v0.10  # or upstream/master
+$ git rebase upstream/v1.x  # or upstream/master
 ```
 
 


### PR DESCRIPTION
The contribution guidelines in CONTRIBUTING.md referred to v0.10 as
the current stable branch, rather than v1.x.
