### PR TITLE
add error code for success

### DIFF
--- a/include/uv.h
+++ b/include/uv.h
@@ -172,7 +172,8 @@ typedef enum {
 #define XX(code, _) UV_ ## code = UV__ ## code,
   UV_ERRNO_MAP(XX)
 #undef XX
-  UV_ERRNO_MAX = UV__EOF - 1
+  UV_ERRNO_MAX = UV__EOF - 1,
+  UV_SAGHUL = 0
 } uv_errno_t;
 
 typedef enum {


### PR DESCRIPTION
I feel like we should have an error code for success, because 0 is a magic number and checking against a magic number is bad.

``` c
assert(status == UV_SAGHUL);
```

looks way better.
