### PR TITLE
unix: don't abort when out of FDs

### DIFF
--- a/src/unix/loop.c
+++ b/src/unix/loop.c
@@ -62,6 +62,9 @@ int uv__loop_init(uv_loop_t* loop, int default_loop) {
   if (uv__platform_loop_init(loop, default_loop))
     return -1;
 
+  if (uv_async_init(loop, &loop->wq_async, uv__work_done))
+    return -1;
+
   uv_signal_init(loop, &loop->child_watcher);
   uv__handle_unref(&loop->child_watcher);
   loop->child_watcher.flags |= UV__HANDLE_INTERNAL;
@@ -70,9 +73,6 @@ int uv__loop_init(uv_loop_t* loop, int default_loop) {
     ngx_queue_init(loop->process_handles + i);
 
   if (uv_mutex_init(&loop->wq_mutex))
-    abort();
-
-  if (uv_async_init(loop, &loop->wq_async, uv__work_done))
     abort();
 
   uv__handle_unref(&loop->wq_async);


### PR DESCRIPTION
When using uv_loop_new() and the system is low on FDs an abort will be
triggered due to uv_async_init() failing.

To fix this uv_async_init() has been moved up uv__loop_init() so that
allocations are not done before the FD creation and if the FD creation
fails we return -1.  This will gracefully cause uv_loop_new() to fail so
the application can handle it.

Fixes #1510 
