### PR TITLE
Windows: update loop time lazily

### DIFF
--- a/include/uv-win.h
+++ b/include/uv-win.h
@@ -315,7 +315,9 @@ RB_HEAD(uv_timer_tree_s, uv_timer_s);
     /* The loop's I/O completion port */                                      \
   HANDLE iocp;                                                                \
   /* The current time according to the event loop. in msecs. */               \
-  uint64_t time;                                                              \
+  /* Don't access these fields directly. Use uv__loop_time() instead. */      \
+  uint64_t cached_time;                                                       \
+  int cached_time_is_valid;                                                   \
   /* Tail of a single-linked circular queue of pending reqs. If the queue */  \
   /* is empty, tail_ is NULL. If there is only one item, */                   \
   /* tail_->next_req == tail_ */                                              \

--- a/src/unix/timer.c
+++ b/src/unix/timer.c
@@ -26,6 +26,11 @@
 #include <limits.h>
 
 
+uint64_t uv_now(const uv_loop_t* loop) {
+  return loop->time;
+}
+
+
 static int timer_less_than(const struct heap_node* ha,
                            const struct heap_node* hb) {
   const uv_timer_t* a;

--- a/src/uv-common.c
+++ b/src/uv-common.c
@@ -391,12 +391,6 @@ void uv_stop(uv_loop_t* loop) {
 }
 
 
-uint64_t uv_now(const uv_loop_t* loop) {
-  return loop->time;
-}
-
-
-
 size_t uv__count_bufs(const uv_buf_t bufs[], unsigned int nbufs) {
   unsigned int i;
   size_t bytes;

--- a/src/win/core.c
+++ b/src/win/core.c
@@ -133,11 +133,8 @@ int uv_loop_init(uv_loop_t* loop) {
   if (loop->iocp == NULL)
     return uv_translate_sys_error(GetLastError());
 
-  /* To prevent uninitialized memory access, loop->time must be intialized
-   * to zero before calling uv_update_time for the first time.
-   */
-  loop->time = 0;
-  uv_update_time(loop);
+  loop->cached_time = 0;
+  loop->cached_time_is_valid = 0;
 
   QUEUE_INIT(&loop->wq);
   QUEUE_INIT(&loop->handle_queue);

--- a/src/win/internal.h
+++ b/src/win/internal.h
@@ -245,6 +245,7 @@ void uv_timer_endgame(uv_loop_t* loop, uv_timer_t* handle);
 DWORD uv__next_timeout(const uv_loop_t* loop);
 void uv__time_forward(uv_loop_t* loop, uint64_t msecs);
 void uv_process_timers(uv_loop_t* loop);
+uint64_t uv__loop_time(const uv_loop_t* loop);
 
 
 /*


### PR DESCRIPTION
We call uv_update_time() whenever we think the loop time should be updated.
But we might not need to read the time after every update, and the update
operation has non-negligible cost.
So I am making uv_update_time() invalidate the loop time. The time will be
actually updated only on the first call to uv_now() after it's been
invalidated.
