### PR TITLE
unix, windows: don't include null byte in uv_cwd size

### DIFF
--- a/src/unix/core.c
+++ b/src/unix/core.c
@@ -637,7 +637,7 @@ int uv_cwd(char* buffer, size_t* size) {
   if (getcwd(buffer, *size) == NULL)
     return -errno;
 
-  *size = strlen(buffer) + 1;
+  *size = strlen(buffer);
   return 0;
 }
 

--- a/src/win/util.c
+++ b/src/win/util.c
@@ -206,7 +206,7 @@ int uv_cwd(char* buffer, size_t* size) {
   if (r == 0) {
     return uv_translate_sys_error(GetLastError());
   } else if (r > (int) *size) {
-    *size = r;
+    *size = r -1;
     return UV_ENOBUFS;
   }
 
@@ -223,7 +223,7 @@ int uv_cwd(char* buffer, size_t* size) {
     return uv_translate_sys_error(GetLastError());
   }
 
-  *size = r;
+  *size = r - 1;
   return 0;
 }
 


### PR DESCRIPTION
Make it consistent with uv_exepath
