### PR TITLE
windows: fix fs_read with nbufs > 1 and offset too

### DIFF
--- a/src/win/fs.c
+++ b/src/win/fs.c
@@ -558,10 +558,6 @@ void fs__read(uv_fs_t* req) {
   if (offset != -1) {
     memset(&overlapped, 0, sizeof overlapped);
 
-    offset_.QuadPart = offset;
-    overlapped.Offset = offset_.LowPart;
-    overlapped.OffsetHigh = offset_.HighPart;
-
     overlapped_ptr = &overlapped;
   } else {
     overlapped_ptr = NULL;
@@ -571,6 +567,13 @@ void fs__read(uv_fs_t* req) {
   bytes = 0;
   do {
     DWORD incremental_bytes;
+
+    if (offset != -1) {
+      offset_.QuadPart = offset + bytes;
+      overlapped.Offset = offset_.LowPart;
+      overlapped.OffsetHigh = offset_.HighPart;
+    }
+
     result = ReadFile(handle,
                       req->bufs[index].base,
                       req->bufs[index].len,
@@ -623,7 +626,6 @@ void fs__write(uv_fs_t* req) {
   do {
     DWORD incremental_bytes;
 
-    /* WriteFile() does not advance overlapped as ReadFile() does. */
     if (offset != -1) {
       offset_.QuadPart = offset + bytes;
       overlapped.Offset = offset_.LowPart;

--- a/test/test-fs.c
+++ b/test/test-fs.c
@@ -109,6 +109,7 @@ static uv_fs_t utime_req;
 static uv_fs_t futime_req;
 
 static char buf[32];
+static char buf2[32];
 static char test_buf[] = "test-buffer\n";
 static char test_buf2[] = "second-buffer\n";
 static uv_buf_t iov;
@@ -2200,12 +2201,15 @@ TEST_IMPL(fs_write_multiple_bufs) {
   uv_fs_req_cleanup(&open_req1);
 
   memset(buf, 0, sizeof(buf));
-  iov = uv_buf_init(buf, sizeof(buf));
-  r = uv_fs_read(loop, &read_req, open_req1.result, &iov, 1, -1, NULL);
+  memset(buf2, 0, sizeof(buf2));
+  /* Read the strings back to separate buffers. */
+  iovs[0] = uv_buf_init(buf, sizeof(test_buf));
+  iovs[1] = uv_buf_init(buf2, sizeof(test_buf2));
+  r = uv_fs_read(loop, &read_req, open_req1.result, iovs, 2, 0, NULL);
   ASSERT(r >= 0);
   ASSERT(read_req.result >= 0);
-  ASSERT(memcmp(buf, test_buf, sizeof(test_buf)) == 0);
-  ASSERT(strcmp(buf + sizeof(test_buf), test_buf2) == 0);
+  ASSERT(strcmp(buf, test_buf) == 0);
+  ASSERT(strcmp(buf2, test_buf2) == 0);
   uv_fs_req_cleanup(&read_req);
 
   iov = uv_buf_init(buf, sizeof(buf));


### PR DESCRIPTION
Had a reason to actually read multiple bufs now, and found it was actually broken on Windows too.

Should not have made assumptions from the existing code and MSDN documentation, ReadFile() does not seem to update the offset at all.

-[Unknown]
