### PR TITLE
win: fix uv_thread_self()

### DIFF
--- a/docs/src/threading.rst
+++ b/docs/src/threading.rst
@@ -56,7 +56,7 @@ Threads
 ^^^^^^^
 
 .. c:function:: int uv_thread_create(uv_thread_t* tid, uv_thread_cb entry, void* arg)
-.. c:function:: unsigned long uv_thread_self(void)
+.. c:function:: uv_thread_t uv_thread_self(void)
 .. c:function:: int uv_thread_join(uv_thread_t *tid)
 .. c:function:: int uv_thread_equal(const uv_thread_t* t1, const uv_thread_t* t2)
 

--- a/include/uv-win.h
+++ b/include/uv-win.h
@@ -232,7 +232,7 @@ typedef int uv_file;
 typedef SOCKET uv_os_sock_t;
 typedef HANDLE uv_os_fd_t;
 
-typedef HANDLE uv_thread_t;
+typedef DWORD uv_thread_t;
 
 typedef HANDLE uv_sem_t;
 

--- a/src/uv-common.c
+++ b/src/uv-common.c
@@ -293,8 +293,10 @@ int uv_thread_create(uv_thread_t *tid, void (*entry)(void *arg), void *arg) {
   ctx->arg = arg;
 
 #ifdef _WIN32
-  *tid = (HANDLE) _beginthreadex(NULL, 0, uv__thread_start, ctx, 0, NULL);
-  err = *tid ? 0 : errno;
+  if (_beginthreadex(NULL, 0, uv__thread_start, ctx, 0, tid))
+    err = 0;
+  else
+    err = errno;
 #else
   err = pthread_create(tid, NULL, uv__thread_start, ctx);
 #endif

--- a/src/win/thread.c
+++ b/src/win/thread.c
@@ -119,13 +119,20 @@ void uv_once(uv_once_t* guard, void (*callback)(void)) {
 
 
 int uv_thread_join(uv_thread_t *tid) {
-  if (WaitForSingleObject(*tid, INFINITE))
+  int err;
+  HANDLE thread = OpenThread(SYNCHRONIZE, FALSE, *tid);
+  if (thread == NULL)
     return uv_translate_sys_error(GetLastError());
+  
+  if (WaitForSingleObject(thread, INFINITE))
+    err = uv_translate_sys_error(GetLastError());
   else {
-    CloseHandle(*tid);
+    err = 0;
     *tid = 0;
-    return 0;
   }
+
+  CloseHandle(thread);
+  return err;
 }
 
 


### PR DESCRIPTION
59658a8de7cc05a58327a164fd2ed4b050f8b4f4 changed uv_thread_self()
to return uv_thread_t, but uv_thread_t is a thread's HANDLE while
uv_thread_self() returns the current thread's id.
This means that uv_thread_equal() is also broken, as we are
potentially comparing HANDLES to ids.

Changed uv_thread_t to DWORD.
Fixed small doc issue.
