### PR TITLE
test: support unix symlink

### DIFF
--- a/test/runner-unix.c
+++ b/test/runner-unix.c
@@ -25,7 +25,7 @@
 #include <stdint.h> /* uintptr_t */
 
 #include <errno.h>
-#include <unistd.h> /* usleep */
+#include <unistd.h> /* usleep, readlink */
 #include <string.h> /* strdup */
 #include <stdio.h>
 #include <stdlib.h>
@@ -49,7 +49,7 @@ void platform_init(int argc, char **argv) {
   /* Disable stdio output buffering. */
   setvbuf(stdout, NULL, _IONBF, 0);
   setvbuf(stderr, NULL, _IONBF, 0);
-  strncpy(executable_path, argv[0], sizeof(executable_path) - 1);
+  readlink(OS_CURRENT_EXECUTABLE_SYMLINK, executable_path, PATHMAX);
   signal(SIGPIPE, SIG_IGN);
 }
 

--- a/test/runner-unix.h
+++ b/test/runner-unix.h
@@ -33,4 +33,10 @@ typedef struct {
   int terminated;
 } process_info_t;
 
+#ifdef __linux__
+  #define OS_CURRENT_EXECUTABLE_SYMLINK "/proc/self/exe"
+#else
+  #define OS_CURRENT_EXECUTABLE_SYMLINK "/proc/curproc/file"
+#endif
+
 #endif  /* TEST_RUNNER_UNIX_H */


### PR DESCRIPTION
The pull-request by:
https://github.com/joyent/libuv/issues/1559#issuecomment-62137079

It solve the problem that is failure to the test as `test-get-currentexe` unexpected if run with a path included symlinks.
