### PR TITLE
docs/src: fix typo: Strcutures -> Structures

### DIFF
--- a/docs/src/handle.rst
+++ b/docs/src/handle.rst
@@ -6,7 +6,7 @@
 
 `uv_handle_t` is the base type for all libuv handle types.
 
-Strcutures are aligned so that any libuv handle can be cast to `uv_handle_t`.
+Structures are aligned so that any libuv handle can be cast to `uv_handle_t`.
 All API functions defined here work with any handle type.
 
 

--- a/docs/src/request.rst
+++ b/docs/src/request.rst
@@ -6,7 +6,7 @@
 
 `uv_req_t` is the base type for all libuv request types.
 
-Strcutures are aligned so that any libuv request can be cast to `uv_req_t`.
+Structures are aligned so that any libuv request can be cast to `uv_req_t`.
 All API functions defined here work with any request type.
 
 


### PR DESCRIPTION
Fix a typo error in docs/src/handle.rst & docs/src/request.rst

Signed-off-by: Michael Ira Krufky m.krufky@samsung.com
