### PR TITLE
build: fix build on SmartOS

### DIFF
--- a/src/unix/tty.c
+++ b/src/unix/tty.c
@@ -123,7 +123,16 @@ int uv_tty_set_mode(uv_tty_t* tty, int mode) {
     uv_spinlock_unlock(&termios_spinlock);
 
     raw = tty->orig_termios;
+#ifdef __sun
+    raw.c_iflag &= ~(BRKINT | ICRNL | INPCK | ISTRIP | IXON);
+    raw.c_oflag |= (ONLCR);
+    raw.c_cflag |= (CS8);
+    raw.c_lflag &= ~(ECHO | ICANON | IEXTEN | ISIG);
+    raw.c_cc[VMIN] = 1;
+    raw.c_cc[VTIME] = 0;
+#else
     cfmakeraw(&raw);
+#endif /* #ifdef __sun */
 
     /* Put terminal in raw mode after draining */
     if (tcsetattr(fd, TCSADRAIN, &raw))


### PR DESCRIPTION
On Solaris based OSes, cfmakeraw is not available. On these platforms,
manually set the terminal in raw mode instead of using cfmakeraw.
